### PR TITLE
Replace tab with 8 spaces not 4 spaces

### DIFF
--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -93,14 +93,14 @@ class SimpleConfig(PrintError):
             self.print_error("Making directory {} and copying wallets".format(path))
             os.makedirs(path)
             electrum_path = user_dir(True)
-	    if self.get('testnet'):
+            if self.get('testnet'):
                 electrum_path = os.path.join(electrum_path, 'testnet')
             elif self.get('nolnet'):
                 electrum_path = os.path.join(electrum_path, 'nolnet')
             if os.path.exists(electrum_path):
                 # Deliberately don't copy config
                 shutil.copytree(os.path.join(electrum_path, 'wallets'), os.path.join(path, 'wallets'))
-	self.print_error("electron-cash directory", path)
+        self.print_error("electron-cash directory", path)
         return path
 
     def fixup_config_keys(self, config, keypairs):


### PR DESCRIPTION
https://stackoverflow.com/questions/2034517/pythons-interpretation-of-tabs-and-spaces-to-indent

My previous merge request I apologize, I replaced tabs with 4 spaces because I misunderstood the way Python2 interprets mixed tabs and spaces.

Currently, Python will replace every tab with 1-8 spaces so that the total number of spaces totals to a multiple of 8.

These two tabs being here randomly could cause problems down the road, so getting them out of the way now would be beneficial.