### PR TITLE
Fix transaction loading to include value if your own transaction.

### DIFF
--- a/gui/kivy/main_window.py
+++ b/gui/kivy/main_window.py
@@ -305,6 +305,14 @@ class ElectrumWindow(App):
             text = base_decode(data, None, base=43).encode('hex')
             tx = Transaction(text)
             tx.deserialize()
+            if self.wallet:
+                my_coins = self.wallet.get_spendable_coins(None, self.electrum_config)
+                my_outpoints = [vin['prevout_hash'] + ':' + str(vin['prevout_n']) for vin in my_coins]
+                for i, txin in enumerate(tx.inputs()):
+                    outpoint = txin['prevout_hash'] + ':' + str(txin['prevout_n'])
+                    if outpoint in my_outpoints:
+                        my_index = my_outpoints.index(outpoint)
+                        tx._inputs[i]['value'] = my_coins[my_index]['value']
         except:
             tx = None
         if tx:


### PR DESCRIPTION
Was going to implement at the parse_input method in transaction.py... but there are many cases where there might not be a wallet, and loading the wallet into transaction.py seemed silly.