### PR TITLE
fix command line multisig bug. Maybe code need to be formated or perfected

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -242,6 +242,16 @@ class Commands:
             x_pubkey = 'fd' + (chr(0) + h160).encode('hex')
             tx.sign({x_pubkey:privkey})
         else:
+            tx.deserialize()
+            if self.wallet:
+                my_coins = self.wallet.get_spendable_coins(None, self.config)
+                my_outpoints = [vin['prevout_hash'] + ':' + str(vin['prevout_n']) for vin in my_coins]
+                for i, txin in enumerate(tx.inputs()):
+                    outpoint = txin['prevout_hash'] + ':' + str(txin['prevout_n'])
+                    if outpoint in my_outpoints:
+                        my_index = my_outpoints.index(outpoint)
+                        tx._inputs[i]['value'] = my_coins[my_index]['value']
+            # tx.serialize()
             self.wallet.sign_transaction(tx, password)
         return tx.as_dict()
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/local/bin/electron-cash", line 4, in <module>
    __import__('pkg_resources').run_script('Electron-Cash==2.9.3', 'electron-cash')
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 748, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 1517, in run_script
    exec(code, namespace, namespace)
  File "/usr/local/lib/python2.7/dist-packages/Electron_Cash-2.9.3-py2.7.egg/EGG-INFO/scripts/electron-cash", line 423, in <module>
    result = run_offline_command(config, config_options)
  File "/usr/local/lib/python2.7/dist-packages/Electron_Cash-2.9.3-py2.7.egg/EGG-INFO/scripts/electron-cash", line 286, in run_offline_command
    result = func(*args)
  File "/usr/local/lib/python2.7/dist-packages/Electron_Cash-2.9.3-py2.7.egg/electrum/commands.py", line 86, in func_wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/Electron_Cash-2.9.3-py2.7.egg/electrum/commands.py", line 245, in signtransaction
    self.wallet.sign_transaction(tx, password)
  File "/usr/local/lib/python2.7/dist-packages/Electron_Cash-2.9.3-py2.7.egg/electrum/wallet.py", line 1104, in sign_transaction
    k.sign_transaction(tx, password)
  File "/usr/local/lib/python2.7/dist-packages/Electron_Cash-2.9.3-py2.7.egg/electrum/keystore.py", line 114, in sign_transaction
    tx.sign(keypairs)
  File "/usr/local/lib/python2.7/dist-packages/Electron_Cash-2.9.3-py2.7.egg/electrum/transaction.py", line 829, in sign
    pre_hash = Hash(self.serialize_preimage(i).decode('hex'))
  File "/usr/local/lib/python2.7/dist-packages/Electron_Cash-2.9.3-py2.7.egg/electrum/transaction.py", line 727, in serialize_preimage
    amount = int_to_hex(txin['value'], 8)
KeyError: 'value'