### PR TITLE
fix SimpleConfig test & un-reported minor bug writing user config

### DIFF
--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -141,12 +141,12 @@ class SimpleConfig(PrintError):
             return
         path = os.path.join(self.path, "config")
         s = json.dumps(self.user_config, indent=4, sort_keys=True)
-        f = open(path, "w")
+        if 'ANDROID_DATA' not in os.environ:
+            f = os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT, 0o600), 'w')
+        else:
+            f = open(path, "w")
         f.write(s)
         f.close()
-        if 'ANDROID_DATA' not in os.environ:
-            import stat
-            os.chmod(path, stat.S_IREAD | stat.S_IWRITE)
 
     def get_wallet_path(self):
         """Set the path of the wallet."""

--- a/lib/tests/test_simple_config.py
+++ b/lib/tests/test_simple_config.py
@@ -166,7 +166,7 @@ class Test_SimpleConfig(unittest.TestCase):
                               read_user_dir_function=read_user_dir)
         config.save_user_config()
         contents = None
-        with open(os.path.join(self.electrum_dir, "config"), "r") as f:
+        with open(os.path.join(self.user_dir, "config"), "r") as f:
             contents = f.read()
         result = ast.literal_eval(contents)
         self.assertEqual({"something": "a"}, result)


### PR DESCRIPTION
Bug in the SimpleConfig test was probably typo.

While checking this, found a bug in the save_user_config() - Rather than "write contents to file and then set permissions", should open the file from the beginning with the correct permissions.