### PR TITLE
issue #117 - export labels filename 

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2177,7 +2177,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     def do_export_labels(self):
         labels = self.wallet.labels
         try:
-            fileName = self.getSaveFileName(_("Select file to save your labels"), 'electrum_labels.json', "*.json")
+            fileName = self.getSaveFileName(_("Select file to save your labels"), 'electron-cash_labels.json', "*.json")
             if fileName:
                 with open(fileName, 'w+') as f:
                     json.dump(labels, f, indent=4, sort_keys=True)


### PR DESCRIPTION
filename from 'electrum_labels.json' to 'electron-cash_labels.json'

fixes #117