### PR TITLE
Add input values to tx in wallet before signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ dist/
 *.egg/
 /electrum.py
 contrib/pyinstaller/
-Electrum.egg-info/
+Electron_Cash.egg-info/
 gui/qt/icons_rc.py
 locale/
 .devlocaltmp/
@@ -24,3 +24,6 @@ bin/
 # MacOSX
 .DS_Store/
 icons/.DS_Store/
+
+# IntelliJ Pycharm IDE
+.idea

--- a/lib/tests/sample_tx.py
+++ b/lib/tests/sample_tx.py
@@ -1,0 +1,140 @@
+# sample transactions, for testnet and mainnet
+# list of samples, each sample will be tested depending on supplied parameters
+# each sample is a dict of
+#       raw - signed tx blob
+#       tx - expected deserialization of 'raw'
+#       raw_unsigned - unsigned tx blob
+#       tx_unsigned - expected deserialization of 'raw_unsigned'
+#       outputs - expected output of tx.get_outputs()
+#       ouputaddresses - expected output of tx.get_output_addresses(), also used to test tx.has_address()
+#       txid - the id of the complete (signed) tx - used to test Transaction.txid()
+#       keypairs - key pairs for signing tx - BE CAREFUL ONLY USE TESTNET
+#       inputvalues - the values of inputs
+sample_tx_testnet = [
+    {  # standard tx, from public testnet electron cash wallet to another testnet electron cash wallet
+        'raw_unsigned': '0100000001f67f0082045b3da782a3c44ff677e8f6f711fc8bf744c85298f8f15883b0fce7000000005701ff4c53ff043587cf000000000000000000b5668482ecaab929ba9d04c358f171901398519b8c81b3ae860ed68ab0ecf01e023cc396f788f47edee48068fe79ec46cf4065d8cc3546a03648cad58aa281b56d00000000feffffff0210270000000000001976a9147adbcfb7469cee9efcede1353d205fdb32b0566988ac94560100000000001976a914e045289a6ba6806055b2e9aa96dd92ad83afc18888ac00000000',
+        'tx_unsigned': {
+            'inputs': [{
+                'signatures': [None],
+                'prevout_hash': 'e7fcb08358f1f89852c844f78bfc11f7f6e877f64fc4a382a73d5b0482007ff6',
+                'scriptSig': '01ff4c53ff043587cf000000000000000000b5668482ecaab929ba9d04c358f171901398519b8c81b3ae860ed68ab0ecf01e023cc396f788f47edee48068fe79ec46cf4065d8cc3546a03648cad58aa281b56d00000000',
+                'sequence': 4294967294,
+                'x_pubkeys': [
+                    'ff043587cf000000000000000000b5668482ecaab929ba9d04c358f171901398519b8c81b3ae860ed68ab0ecf01e023cc396f788f47edee48068fe79ec46cf4065d8cc3546a03648cad58aa281b56d00000000'
+                ],
+                'address': 'mx6w8bqyDQHZUJP6vAUVgXAoL6U1QnDgEJ',
+                'num_sig': 1,
+                'pubkeys': ['035996a16b51eed04a678aa0c5637a0d6d688ac2b6c2b36cc646af72381337c669'],
+                'type': 'p2pkh',
+                'prevout_n': 0
+            }],
+            'lockTime': 0,
+            'version': 1,
+            'outputs': [{
+                'prevout_n': 0,
+                'scriptPubKey': '76a9147adbcfb7469cee9efcede1353d205fdb32b0566988ac',
+                'type': 0,
+                'value': 10000,
+                'address': 'mria4Djx9XZ3zJLYxSEfd7ShcJNdTHMmst'
+            },{
+                'prevout_n': 1,
+                'scriptPubKey': '76a914e045289a6ba6806055b2e9aa96dd92ad83afc18888ac',
+                'type': 0,
+                'value': 87700,
+                'address': 'n1xnWFMLF9xkcUxL3ZwQKbGkRNBpGKdFjt'
+            }]
+        },
+        'keypairs': {'ff043587cf000000000000000000b5668482ecaab929ba9d04c358f171901398519b8c81b3ae860ed68ab0ecf01e023cc396f788f47edee48068fe79ec46cf4065d8cc3546a03648cad58aa281b56d00000000': 'cW66cr1e6sXF4T5QuAzU6UZbrVkMuPeuTWhodZX2MJ1kdBkr3r7A'},
+        'inputvalues': [100000],
+        'raw': '0100000001f67f0082045b3da782a3c44ff677e8f6f711fc8bf744c85298f8f15883b0fce7000000006b48304502210082422e8b395e44e60d116652465ff22157ee3abbb2529163aeabc0c57bee718c02206d2c19bda83b6c8e861ed9936eda93819364dafefa2a14517b7958b9d59d05124121035996a16b51eed04a678aa0c5637a0d6d688ac2b6c2b36cc646af72381337c669feffffff0210270000000000001976a9147adbcfb7469cee9efcede1353d205fdb32b0566988ac94560100000000001976a914e045289a6ba6806055b2e9aa96dd92ad83afc18888ac00000000',
+        'outputs': [('mria4Djx9XZ3zJLYxSEfd7ShcJNdTHMmst', 10000),('n1xnWFMLF9xkcUxL3ZwQKbGkRNBpGKdFjt',87700)],
+        'outputaddresses': ['mria4Djx9XZ3zJLYxSEfd7ShcJNdTHMmst','n1xnWFMLF9xkcUxL3ZwQKbGkRNBpGKdFjt'],
+        'input_txs': ['01000000010607d3ce6eb8e892ef110d26643c962fd53d04ea4c4429ef0954e17ae9d9ef28000000006b483045022100cee875b264d8b201b197eb0b062793925add3d924d53904a22a42c9f6d60779502201a166c4bb0cd3eea7d8953acc450ff8bf1daeb5823d6931788e5b438b2bbc890412102ef9e36c431cdfa97033ffef9f19a7a9bd849f5db45054ecd4007a5893e17c6d3feffffff02a0860100000000001976a914b5ef2f37793fa1c0a7fff8363685ced547d46eee88ac3cba7a4d000000001976a91495b2610cb0759125b382e6cacef6542b7a592e9088ac00000000'],
+    },
+]
+
+sample_tx_mainnet = [
+    {
+        'raw': '020000000121f8030318ce76131e8b3c8f45e0c520e6a8e06515766080edfada23658a5512000000006a47304402203422fad67115b00671af96510b73b87b71499dbd9b482c1bb5aa5da4533ff411022021a49b5448f463d6b54da24d86da872b9e9883fc5bfac2063c1cebde2c2da7264121028bbab2552f9568b687915d68a2ce55f682a81da4a63120b9d8d72db43cc657c1feffffff02802600000000000017a9143284a4e0b824fea4fad46dd764712459bdc49dca87e14d0900000000001976a914a306d546bbaa717f90d788cc8edc21f537cc4d2b88ac9c8b0700',
+        'txid': 'c15f904d85e0773d46f5418237422fceb9762e718d21369dc7dfe0a078e7f3b5',
+        'tx': {
+            'inputs': [{
+                'signatures': ['304402203422fad67115b00671af96510b73b87b71499dbd9b482c1bb5aa5da4533ff411022021a49b5448f463d6b54da24d86da872b9e9883fc5bfac2063c1cebde2c2da72641'],
+                'prevout_hash': '12558a6523dafaed8060761565e0a8e620c5e0458f3c8b1e1376ce180303f821',
+                'scriptSig': '47304402203422fad67115b00671af96510b73b87b71499dbd9b482c1bb5aa5da4533ff411022021a49b5448f463d6b54da24d86da872b9e9883fc5bfac2063c1cebde2c2da7264121028bbab2552f9568b687915d68a2ce55f682a81da4a63120b9d8d72db43cc657c1',
+                'sequence': 4294967294,
+                'x_pubkeys': ['028bbab2552f9568b687915d68a2ce55f682a81da4a63120b9d8d72db43cc657c1'],
+                'address': '1331F4BdeChHwFr9njUB78c2LwF87EJjjT',
+                'num_sig': 1,
+                'pubkeys': ['028bbab2552f9568b687915d68a2ce55f682a81da4a63120b9d8d72db43cc657c1'],
+                'type': 'p2pkh',
+                'prevout_n': 0
+            }],
+            'lockTime': 494492,
+            'version': 2,
+            'outputs': [{
+                'prevout_n': 0,
+                'scriptPubKey': 'a9143284a4e0b824fea4fad46dd764712459bdc49dca87',
+                'type': 0,
+                'value': 9856,
+                'address': '36J8cQV5WZVRxxZJ3DwRjeta1RH9QRR3FN'
+            }, {
+                'prevout_n': 1,
+                'scriptPubKey': '76a914a306d546bbaa717f90d788cc8edc21f537cc4d2b88ac',
+                'type': 0,
+                'value': 609761,
+                'address': '1Fs1L3PcASQC5AKyZ5ahdJFeJMN7MNSwXg'
+            }]
+        },
+    },
+    {
+        'txid': 'b78209426e08bf64147de99ee84014daa212d8942d28dbe5c5e552d818579fe0',
+        'raw': '02000000026540eb0223a46ccd7de94ac68cf29b81030c6388dd8feb87442f115610c88724010000008b4830450221008bf9e5a522d3e229e25a185178ccbd9ff957c87480ca70ada25dd1b1755b79d802200bbfc99d8ae21a35bb4141dea0529aea114e57fd08f5c13d559f6eed17ec2bd8414104dcab7b8f51749c30390e85cafa0f0a7d3c5ea596575f59d21b8bab966294a0527fc8de2cc96a9f5f806a5a969be6ff42326745acf0bd2d2f36b66c7977ef3323ffffffff37b3b68131907d3691018771efff9e090d6db30ea7247ecc76fb6085a5b98cd8020000008a473044022065b73305c421af4fafd62e720951155c09ed9db5058aec966690a58664e88dc402202b2c7fddbb4ed77cb66bcda1add2da5e96db53be0a8168357ab697b7fb0df7b24141040baa4271a82c5f1a09a5ea63d763697ca0545b6049c4dd8e8d099dd91f2da10eb11e829000a82047ac56969fb582433067a21c3171e569d1832c34fdd793cfc8ffffffff030000000000000000226a20e73f3eac9da99afe7dc7822828a705f07d271372411494e58391d08ceb0ce508e4412b01000000001976a9148b80536aa3c460258cda834b86a46787c9a2b0bf88ac51bf0700000000001976a914a62d57e0f658a7926959099f617a850206063dae88ac00000000',
+        'tx': {
+            'inputs': [{
+                'signatures': ['30450221008bf9e5a522d3e229e25a185178ccbd9ff957c87480ca70ada25dd1b1755b79d802200bbfc99d8ae21a35bb4141dea0529aea114e57fd08f5c13d559f6eed17ec2bd841'],
+                'prevout_hash': '2487c81056112f4487eb8fdd88630c03819bf28cc64ae97dcd6ca42302eb4065',
+                'scriptSig': '4830450221008bf9e5a522d3e229e25a185178ccbd9ff957c87480ca70ada25dd1b1755b79d802200bbfc99d8ae21a35bb4141dea0529aea114e57fd08f5c13d559f6eed17ec2bd8414104dcab7b8f51749c30390e85cafa0f0a7d3c5ea596575f59d21b8bab966294a0527fc8de2cc96a9f5f806a5a969be6ff42326745acf0bd2d2f36b66c7977ef3323',
+                'sequence': 4294967295,
+                'x_pubkeys': ['04dcab7b8f51749c30390e85cafa0f0a7d3c5ea596575f59d21b8bab966294a0527fc8de2cc96a9f5f806a5a969be6ff42326745acf0bd2d2f36b66c7977ef3323'],
+                'address': '1Dice5ycHmxDHUFVkdKGgrwsDDK1mPES3U',
+                'num_sig': 1,
+                'pubkeys': ['04dcab7b8f51749c30390e85cafa0f0a7d3c5ea596575f59d21b8bab966294a0527fc8de2cc96a9f5f806a5a969be6ff42326745acf0bd2d2f36b66c7977ef3323'],
+                'type': 'p2pkh',
+                'prevout_n': 1
+            }, {
+                'signatures': ['3044022065b73305c421af4fafd62e720951155c09ed9db5058aec966690a58664e88dc402202b2c7fddbb4ed77cb66bcda1add2da5e96db53be0a8168357ab697b7fb0df7b241'],
+                'prevout_hash': 'd88cb9a58560fb76cc7e24a70eb36d0d099effef71870191367d903181b6b337',
+                'scriptSig': '473044022065b73305c421af4fafd62e720951155c09ed9db5058aec966690a58664e88dc402202b2c7fddbb4ed77cb66bcda1add2da5e96db53be0a8168357ab697b7fb0df7b24141040baa4271a82c5f1a09a5ea63d763697ca0545b6049c4dd8e8d099dd91f2da10eb11e829000a82047ac56969fb582433067a21c3171e569d1832c34fdd793cfc8',
+                'sequence': 4294967295,
+                'x_pubkeys': ['040baa4271a82c5f1a09a5ea63d763697ca0545b6049c4dd8e8d099dd91f2da10eb11e829000a82047ac56969fb582433067a21c3171e569d1832c34fdd793cfc8'],
+                'address': '1DiceuELb5GZktc3CMEv868DMtU3B5957x',
+                'num_sig': 1,
+                'pubkeys': ['040baa4271a82c5f1a09a5ea63d763697ca0545b6049c4dd8e8d099dd91f2da10eb11e829000a82047ac56969fb582433067a21c3171e569d1832c34fdd793cfc8'],
+                'type': 'p2pkh',
+                'prevout_n': 2
+            }],
+            'lockTime': 0,
+            'version': 2,
+            'outputs': [{
+                'prevout_n': 0,
+                'scriptPubKey': '6a20e73f3eac9da99afe7dc7822828a705f07d271372411494e58391d08ceb0ce508',
+                'type': 2,
+                'value': 0,
+                'address': "j \xe7?>\xac\x9d\xa9\x9a\xfe}\xc7\x82((\xa7\x05\xf0}'\x13rA\x14\x94\xe5\x83\x91\xd0\x8c\xeb\x0c\xe5\x08"
+            }, {
+                'prevout_n': 1,
+                'scriptPubKey': '76a9148b80536aa3c460258cda834b86a46787c9a2b0bf88ac',
+                'type': 0,
+                'value': 19612132,
+                'address': '1DiceuELb5GZktc3CMEv868DMtU3B5957x'
+            }, {
+                'prevout_n': 2,
+                'scriptPubKey': '76a914a62d57e0f658a7926959099f617a850206063dae88ac',
+                'type': 0,
+                'value': 507729,
+                'address': '1G9fVMJ9o1PW2tpb4MpoDHN3A8urBa3LCb'
+            }]
+        },
+    }
+]

--- a/lib/tests/test_transaction.py
+++ b/lib/tests/test_transaction.py
@@ -1,17 +1,19 @@
 import unittest
 from lib import transaction
-from lib.bitcoin import TYPE_ADDRESS
+from lib import bitcoin
+from lib.bitcoin import TYPE_ADDRESS, set_testnet
+from sample_tx import sample_tx_mainnet, sample_tx_testnet
 
 import pprint
 from lib.keystore import xpubkey_to_address
 
 v2_blob = "0200000001191601a44a81e061502b7bfbc6eaa1cef6d1e6af5308ef96c9342f71dbf4b9b5000000006b483045022100a6d44d0a651790a477e75334adfb8aae94d6612d01187b2c02526e340a7fd6c8022028bdf7a64a54906b13b145cd5dab21a26bd4b85d6044e9b97bceab5be44c2a9201210253e8e0254b0c95776786e40984c1aa32a7d03efa6bdacdea5f421b774917d346feffffff026b20fa04000000001976a914024db2e87dd7cfd0e5f266c5f212e21a31d805a588aca0860100000000001976a91421919b94ae5cefcdf0271191459157cdb41c4cbf88aca6240700"
 
-class TestBCDataStream(unittest.TestCase):
 
+class TestBCDataStream(unittest.TestCase):
     def test_compact_size(self):
         s = transaction.BCDataStream()
-        values = [0, 1, 252, 253, 2**16-1, 2**16, 2**32-1, 2**32, 2**64-1]
+        values = [0, 1, 252, 253, 2 ** 16 - 1, 2 ** 16, 2 ** 32 - 1, 2 ** 32, 2 ** 64 - 1]
         for v in values:
             s.write_compact_size(v)
 
@@ -48,10 +50,10 @@ class TestBCDataStream(unittest.TestCase):
         self.assertEquals(s.read_bytes(4), 'r')
         self.assertEquals(s.read_bytes(1), '')
 
-class TestTransaction(unittest.TestCase):
 
-    def test_deserialization(self):
-        for sample in sample_tx:
+class TransactionBase(unittest.TestCase):
+    def do_deserialization(self, samples):
+        for sample in samples:
             if 'raw' in sample and 'tx' in sample:
                 tx = transaction.Transaction(sample['raw'])
                 self.assertEquals(tx.deserialize(), sample['tx'])
@@ -59,8 +61,21 @@ class TestTransaction(unittest.TestCase):
                 tx = transaction.Transaction(sample['raw_unsigned'])
                 self.assertEquals(tx.deserialize(), sample['tx_unsigned'])
 
-    def test_outputs(self):
-        for sample in sample_tx:
+    def do_serialization(self, samples):
+        for sample in samples:
+            if 'raw' in sample and 'tx' in sample:
+                tx = transaction.Transaction(sample['raw'])
+                tx.deserialize()
+                del (tx.raw)
+                self.assertEquals(tx.serialize(), sample['raw'])
+            if 'raw_unsigned' in sample and 'tx_unsigned' in sample:
+                tx = transaction.Transaction(sample['raw_unsigned'])
+                tx.deserialize()
+                del (tx.raw)
+                self.assertEquals(tx.serialize(), sample['raw_unsigned'])
+
+    def do_outputs(self, samples):
+        for sample in samples:
             if 'raw' in sample and 'outputs' in sample:
                 tx = transaction.Transaction(sample['raw'])
                 self.assertEquals(tx.get_outputs(), sample['outputs'])
@@ -68,8 +83,8 @@ class TestTransaction(unittest.TestCase):
                 tx = transaction.Transaction(sample['raw_unsigned'])
                 self.assertEquals(tx.get_outputs(), sample['outputs'])
 
-    def test_outputaddresses(self):
-        for sample in sample_tx:
+    def do_outputaddresses(self, samples):
+        for sample in samples:
             if 'raw' in sample and 'outputaddresses' in sample:
                 tx = transaction.Transaction(sample['raw'])
                 self.assertEquals(tx.get_output_addresses(), sample['outputaddresses'])
@@ -77,8 +92,8 @@ class TestTransaction(unittest.TestCase):
                 tx = transaction.Transaction(sample['raw_unsigned'])
                 self.assertEquals(tx.get_output_addresses(), sample['outputaddresses'])
 
-    def test_has_address(self):
-        for sample in sample_tx:
+    def do_has_address(self, samples):
+        for sample in samples:
             if 'raw' in sample and 'outputaddresses' in sample:
                 tx = transaction.Transaction(sample['raw'])
                 for a in sample['outputaddresses']:
@@ -90,17 +105,68 @@ class TestTransaction(unittest.TestCase):
                     self.assertTrue(tx.has_address(a))
                 self.assertFalse(tx.has_address('1CQj15y1N7LDHp7wTt28eoD1QhHgFgxECH'))
 
-    def test_update_signatures(self):
-        # we dont have any samples for this yet
-        for sample in sample_tx:
+    def do_txid(self, samples):
+        for sample in samples:
+            if 'raw' in sample and 'txid' in sample:
+                tx = transaction.Transaction(sample['raw'])
+                self.assertEquals(tx.txid(), sample['txid'])
+
+    def do_update_signatures(self, samples):
+        for sample in samples:
             if 'raw' in sample and 'raw_unsigned' in sample:
                 tx = transaction.Transaction(sample['raw_unsigned'])
-                tx.update_signatures(sample['raw'])
-                self.assertEquals(tx.raw, sample['raw'])
+                with self.assertRaises(transaction.InputValueMissing):
+                    tx.update_signatures(sample['raw'])
+                if 'inputvalues' in sample:
+                    for i, val in enumerate(sample['inputvalues']):
+                        tx._inputs[i]['value'] = val
+                    tx.update_signatures(sample['raw'])
+                    self.assertEquals(tx.raw, sample['raw'])
             elif 'raw' in sample:
+                # nothing should happen
                 tx = transaction.Transaction(sample['raw'])
                 tx.update_signatures(sample['raw'])
                 self.assertEquals(tx.raw, sample['raw'])
+
+    def do_sign(self, samples):
+        ''' test signing tx - need raw_unsigned, raw, keypairs in tx'''
+        for sample in samples:
+            if 'raw_unsigned' in sample and 'raw' in sample and 'keypairs' in sample:
+                tx = transaction.Transaction(sample['raw_unsigned'])
+                tx.deserialize()
+                with self.assertRaises(transaction.InputValueMissing):
+                    tx.sign(sample['keypairs'])
+                if 'inputvalues' in sample:
+                    for i, val in enumerate(sample['inputvalues']):
+                        tx._inputs[i]['value'] = val
+                    tx.sign(sample['keypairs'])
+                    self.assertEquals(tx.serialize(),sample['raw'])
+
+
+class TestTransactionsMainNet(TransactionBase):
+    def test_deserialization(self):
+        self.do_deserialization(sample_tx_mainnet)
+
+    def test_has_addtrss(self):
+        self.do_has_address(sample_tx_mainnet)
+
+    def test_outputaddresses(self):
+        self.do_outputaddresses(sample_tx_mainnet)
+
+    def test_outputs(self):
+        self.do_outputs(sample_tx_mainnet)
+
+    def test_serialization(self):
+        self.do_serialization(sample_tx_mainnet)
+
+    def test_txid(self):
+        self.do_txid(sample_tx_mainnet)
+
+    def test_update_signatures(self):
+        self.do_update_signatures(sample_tx_mainnet)
+
+    def test_sign(self):
+        self.do_sign(sample_tx_mainnet)
 
     def test_errors(self):
         with self.assertRaises(TypeError):
@@ -110,8 +176,11 @@ class TestTransaction(unittest.TestCase):
             xpubkey_to_address('')
 
     def test_parse_xpub(self):
-        res = xpubkey_to_address('fe4e13b0f311a55b8a5db9a32e959da9f011b131019d4cebe6141b9e2c93edcbfc0954c358b062a9f94111548e50bde5847a3096b8b7872dcffadb0e9579b9017b01000200')
-        self.assertEquals(res, ('04ee98d63800824486a1cf5b4376f2f574d86e0a3009a6448105703453f3368e8e1d8d090aaecdd626a45cc49876709a3bbb6dc96a4311b3cac03e225df5f63dfc', '19h943e4diLc68GXW7G75QNe2KWuMu7BaJ'))
+        res = xpubkey_to_address(
+            'fe4e13b0f311a55b8a5db9a32e959da9f011b131019d4cebe6141b9e2c93edcbfc0954c358b062a9f94111548e50bde5847a3096b8b7872dcffadb0e9579b9017b01000200')
+        self.assertEquals(res, (
+        '04ee98d63800824486a1cf5b4376f2f574d86e0a3009a6448105703453f3368e8e1d8d090aaecdd626a45cc49876709a3bbb6dc96a4311b3cac03e225df5f63dfc',
+        '19h943e4diLc68GXW7G75QNe2KWuMu7BaJ'))
 
         res = xpubkey_to_address('fd007d260305ef27224bbcf6cf5238d2b3638b5a78d5')
         self.assertEquals(res, ('fd007d260305ef27224bbcf6cf5238d2b3638b5a78d5', '1CQj15y1N7LDHp7wTt28eoD1QhHgFgxECH'))
@@ -121,61 +190,50 @@ class TestTransaction(unittest.TestCase):
         self.assertEquals(tx.txid(), "b97f9180173ab141b61b9f944d841e60feec691d6daab4d4d932b24dd36606fe")
 
 
-class NetworkMock(object):
+class TestTransactionsTestNet(TransactionBase):
+    def setUp(self):
+        set_testnet()
 
+    def tearDown(self):
+        # restore mainnet again
+        bitcoin.TESTNET = False
+        bitcoin.ADDRTYPE_P2PKH = 0
+        bitcoin.ADDRTYPE_P2SH = 5
+        bitcoin.ADDRTYPE_P2WPKH = 6
+        bitcoin.XPRV_HEADER = 0x0488ade4
+        bitcoin.XPUB_HEADER = 0x0488b21e
+        bitcoin.HEADERS_URL = "http://bitcoincash.com/files/blockchain_headers"
+        bitcoin.GENESIS = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+
+    def test_deserialization(self):
+        self.do_deserialization(sample_tx_testnet)
+
+    def test_has_addtrss(self):
+        self.do_has_address(sample_tx_testnet)
+
+    def test_outputaddresses(self):
+        self.do_outputaddresses(sample_tx_testnet)
+
+    def test_outputs(self):
+        self.do_outputs(sample_tx_testnet)
+
+    def test_serialization(self):
+        self.do_serialization(sample_tx_testnet)
+
+    def test_txid(self):
+        self.do_txid(sample_tx_testnet)
+
+    def test_update_signatures(self):
+        self.do_update_signatures(sample_tx_testnet)
+
+    def test_sign(self):
+        self.do_sign(sample_tx_testnet)
+
+
+class NetworkMock(object):
     def __init__(self, unspent):
         self.unspent = unspent
 
     def synchronous_get(self, arg):
         return self.unspent
 
-
-# sample test transactions
-# list of samples, each sample will be tested depending on supplied parameters
-# each sample is a dict of
-#       raw - signed tx blob
-#       tx - expected deserialization of 'raw'
-#       raw_unsigned - unsigned tx blob
-#       tx_unsigned - expected deserialization of 'raw_unsigned'
-#       outputs - expected output of tx.get_outputs()
-#       ouputaddresses - expected output of tx.get_output_addresses(), also used to test tx.has_address()
-sample_tx = [
-    { 'raw_unsigned': '0100000001f67f0082045b3da782a3c44ff677e8f6f711fc8bf744c85298f8f15883b0fce7000000005701ff4c53ff043587cf000000000000000000b5668482ecaab929ba9d04c358f171901398519b8c81b3ae860ed68ab0ecf01e023cc396f788f47edee48068fe79ec46cf4065d8cc3546a03648cad58aa281b56d00000000feffffff022c970000000000001976a914e045289a6ba6806055b2e9aa96dd92ad83afc18888ac50c30000000000001976a914b6d22863dfffe257f72ed5ad6daaef8ba970139e88ac00000000',
-      'tx_unsigned': {
-            "inputs": [
-                {
-                    "address": None,
-                    "num_sig": 0,
-                    "prevout_hash": "e7fcb08358f1f89852c844f78bfc11f7f6e877f64fc4a382a73d5b0482007ff6",
-                    "prevout_n": 0,
-                    "pubkeys": [],
-                    "scriptSig": "01ff4c53ff043587cf000000000000000000b5668482ecaab929ba9d04c358f171901398519b8c81b3ae860ed68ab0ecf01e023cc396f788f47edee48068fe79ec46cf4065d8cc3546a03648cad58aa281b56d00000000",
-                    "sequence": 4294967294,
-                    "signatures": {},
-                    "type": "unknown",
-                    "x_pubkeys": []
-                }
-            ],
-            "lockTime": 0,
-            "outputs": [
-                {
-                    "address": "1MSqDCGMS8XVqNUiKzy2Vg4RZNb7Q4Sx6C",
-                    "prevout_n": 0,
-                    "scriptPubKey": "76a914e045289a6ba6806055b2e9aa96dd92ad83afc18888ac",
-                    "type": 0,
-                    "value": 38700
-                },
-                {
-                    "address": "1Hffjw1mVEcsTCM6QEXBFXJUTWkwSSypxh",
-                    "prevout_n": 1,
-                    "scriptPubKey": "76a914b6d22863dfffe257f72ed5ad6daaef8ba970139e88ac",
-                    "type": 0,
-                    "value": 50000
-                }
-            ],
-            "version": 1
-        },
-      'outputs': [('1MSqDCGMS8XVqNUiKzy2Vg4RZNb7Q4Sx6C', 38700), ('1Hffjw1mVEcsTCM6QEXBFXJUTWkwSSypxh', 50000)],
-      'outputaddresses': ['1MSqDCGMS8XVqNUiKzy2Vg4RZNb7Q4Sx6C', '1Hffjw1mVEcsTCM6QEXBFXJUTWkwSSypxh']
-    }
-]

--- a/lib/tests/test_wallet.py
+++ b/lib/tests/test_wallet.py
@@ -6,7 +6,11 @@ import os
 import json
 
 from StringIO import StringIO
-from electroncash.storage import WalletStorage, FINAL_SEED_VERSION
+from lib.storage import WalletStorage, FINAL_SEED_VERSION
+import lib.wallet as wallet
+import lib.keystore as keystore
+import lib.bitcoin as bitcoin, lib.transaction as transaction
+from sample_tx import sample_tx_testnet
 
 
 class FakeSynchronizer(object):
@@ -67,3 +71,171 @@ class TestWalletStorage(WalletTestCase):
         with open(self.wallet_path, "r") as f:
             contents = f.read()
         self.assertEqual(some_dict, json.loads(contents))
+
+
+class TestStandardWallet(unittest.TestCase):
+    def setUp(self):
+        bitcoin.set_testnet()
+        self.user_dir = tempfile.mkdtemp()
+        self.wallet_path = os.path.join(self.user_dir, "testwallet")
+        self.storage = WalletStorage(self.wallet_path)
+        k = keystore.from_seed('absent feel require game library trade march seven quantum recycle warfare tomorrow', '')
+        self.storage.put('seed_type', 'standard')
+        self.storage.put('keystore', k.dump())
+        self.wallet = wallet.Standard_Wallet(self.storage)
+        for i in range(2):
+            self.wallet.create_new_address(False)       # normal addresses
+            self.wallet.create_new_address(True)        # change addresses
+        self.wallet.storage.write()
+
+    def tearDown(self):
+        del self.wallet
+        del self.storage
+        shutil.rmtree(self.user_dir)
+        # restore back to mainnet
+        bitcoin.TESTNET = False
+        bitcoin.ADDRTYPE_P2PKH = 0
+        bitcoin.ADDRTYPE_P2SH = 5
+        bitcoin.ADDRTYPE_P2WPKH = 6
+        bitcoin.XPRV_HEADER = 0x0488ade4
+        bitcoin.XPUB_HEADER = 0x0488b21e
+        bitcoin.HEADERS_URL = "http://bitcoincash.com/files/blockchain_headers"
+        bitcoin.GENESIS = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+
+
+    def test_addresses(self):
+        self.assertTrue('mx6w8bqyDQHZUJP6vAUVgXAoL6U1QnDgEJ' in self.wallet.get_addresses())
+        self.assertTrue('n1xnWFMLF9xkcUxL3ZwQKbGkRNBpGKdFjt' in self.wallet.get_addresses())
+        self.assertFalse('invalid address' in self.wallet.get_addresses())
+        self.assertTrue(len(self.wallet.get_addresses()) >= 2)
+
+    def test_add_transaction(self):
+        addedtx = self.add_all_txs()
+        self.assertEqual(len(self.wallet.transactions),len(addedtx))
+        # adding tx's does not automatically update the utxo's
+        self.assertEqual(len(self.wallet.get_utxos()),0)
+
+    # this fails, related to issue 169, being worked on
+    def test_sign(self):
+        for sample in sample_tx_testnet:
+            if 'raw_unsigned' in sample:
+                tx = transaction.Transaction(sample['raw_unsigned'])
+                tx.deserialize()
+                for i in tx.inputs():
+                    self.assertTrue(i['address'] in self.wallet.get_addresses())
+                self.assertFalse(tx.is_complete())
+                # wallet has no tx history, so this should fail
+                with self.assertRaises(transaction.InputValueMissing):
+                    self.wallet.sign_transaction(tx, None)
+                self.assertFalse(tx.is_complete())
+                if 'input_txs' in sample:
+                    for i in sample['input_txs']:       # add the txs for the inputs to the wallet
+                        itx = transaction.Transaction(i)
+                        self.wallet.add_transaction(itx.txid(),itx)
+                    self.wallet.sign_transaction(tx, None)
+                    self.assertTrue(tx.is_complete())
+
+
+    def add_all_txs(self):
+        addedtx = []
+        for sample in sample_tx_testnet:
+            if 'raw' in sample:
+                tx = transaction.Transaction(sample['raw'])
+                if tx.txid() not in addedtx:
+                    self.wallet.add_transaction(tx.txid(),tx)
+                    addedtx.append(tx.txid())
+            if 'input_txs' in sample:
+                for i in sample['input_txs']:
+                    tx = transaction.Transaction(i)
+                    if tx.txid() not in addedtx:
+                        self.wallet.add_transaction(tx.txid(), tx)
+                        addedtx.append(tx.txid())
+        return addedtx
+
+
+class TestMultiSigWallet(unittest.TestCase):
+    def setUp(self):
+        bitcoin.set_testnet()
+        self.user_dir = tempfile.mkdtemp()
+        self.wallet_path = os.path.join(self.user_dir, "multisig2")
+        self.storage = WalletStorage(self.wallet_path)
+        self.storage.put('wallet_type', "2of3")
+        k = [keystore.from_seed('almost cross mistake border loud enable birth worth end helmet flash cliff', '')]
+        k.append(keystore.from_keys('tpubD6NzVbkrYhZ4XikksiCN1DTVgBZUQcKeN5XkbeqhDZei5z15sb34cES57n7BS7zxuN5QSwRtFidx4VMYk9VBoX76CCsek6P2mzWkTj3UtiK'))
+        k.append(keystore.from_keys('tpubD6NzVbkrYhZ4XgqM6axUN9ZhvBhCawMKRsT9Lqxs6fMjj5TAB9cE7vJATk1vuGrpBVaqVPKrSPXeDYJMbLWKN9svbKEW38WAWQq5nU3nqT1'))
+        for i, one_k in enumerate(k):
+            self.storage.put('x%d/' % (i + 1), one_k.dump())
+        self.wallet = wallet.Multisig_Wallet(self.storage)
+        for i in range(2):
+            self.wallet.create_new_address(False)       # normal addresses
+            self.wallet.create_new_address(True)        # change addresses
+        self.wallet.storage.write()
+
+    def tearDown(self):
+        del self.wallet
+        del self.storage
+        shutil.rmtree(self.user_dir)
+        # restore back to mainnet
+        bitcoin.TESTNET = False
+        bitcoin.ADDRTYPE_P2PKH = 0
+        bitcoin.ADDRTYPE_P2SH = 5
+        bitcoin.ADDRTYPE_P2WPKH = 6
+        bitcoin.XPRV_HEADER = 0x0488ade4
+        bitcoin.XPUB_HEADER = 0x0488b21e
+        bitcoin.HEADERS_URL = "http://bitcoincash.com/files/blockchain_headers"
+        bitcoin.GENESIS = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+
+    def test_signfromcmdline(self):
+        # tx has been signed by one in 2of3 multisig - check that it can be completed by second
+        raw_onesign = '0100000001f5c9f455b2321add71f307a9ee7a757770ffa679b42da21e2e1c025f09b0a80f01000000fd1f010001ff01ff483045022100ea5a8a813f70a0ed6919f49ab7b24a45858a66a433694d098f42df53fa2b152702205b2161ba4010a667e24b8a7e1bc18172b04d4e964a5a61e7803e14e68f7aa5c4414ccf524c53ff043587cf000000000000000000877214e20b564ea196f5849d59ee5df75f19c9653e51cbb1b36b5016127d6d7603717353e251530938e2f58e69e4241220a83de34c6a34531dbc8a2d9fab4bf1ef010000004c53ff043587cf000000000000000000496e2dc110ea22d9eccc4cf544073593cbd4cd8bd9cdbb990cfa4be8a1bc3735037fe33cf2c12ca4669a262c753da553af507c45776029d1373b36d995a5d1e3df010000002103f0e6194aadb6eb52d11e1f677af21251cda80a24d409230df6f94c4b4030893853aefeffffff0280969800000000001976a914b6d22863dfffe257f72ed5ad6daaef8ba970139e88ac7099c4040000000017a9140192877a30ab29b73abda5549bbb0a8db01d08128700000000'
+        tx_onesign = {
+            'inputs': [{
+                'redeemScript': '5221024e539282253ccc288f93966e94fecb637f9491718f1c573ced10aa052fea939a2103de64029a56a6a9fb78c8b8f030fc557db85a4f47d1278e556081cd7b2ca381f92103f0e6194aadb6eb52d11e1f677af21251cda80a24d409230df6f94c4b4030893853ae',
+                'signatures': [None, None, '3045022100ea5a8a813f70a0ed6919f49ab7b24a45858a66a433694d098f42df53fa2b152702205b2161ba4010a667e24b8a7e1bc18172b04d4e964a5a61e7803e14e68f7aa5c441'],
+                'prevout_hash': '0fa8b0095f021c2e1ea22db479a6ff7077757aeea907f371dd1a32b255f4c9f5',
+                'scriptSig': '0001ff01ff483045022100ea5a8a813f70a0ed6919f49ab7b24a45858a66a433694d098f42df53fa2b152702205b2161ba4010a667e24b8a7e1bc18172b04d4e964a5a61e7803e14e68f7aa5c4414ccf524c53ff043587cf000000000000000000877214e20b564ea196f5849d59ee5df75f19c9653e51cbb1b36b5016127d6d7603717353e251530938e2f58e69e4241220a83de34c6a34531dbc8a2d9fab4bf1ef010000004c53ff043587cf000000000000000000496e2dc110ea22d9eccc4cf544073593cbd4cd8bd9cdbb990cfa4be8a1bc3735037fe33cf2c12ca4669a262c753da553af507c45776029d1373b36d995a5d1e3df010000002103f0e6194aadb6eb52d11e1f677af21251cda80a24d409230df6f94c4b4030893853ae',
+                'sequence': 4294967294,
+                'x_pubkeys': ['ff043587cf000000000000000000877214e20b564ea196f5849d59ee5df75f19c9653e51cbb1b36b5016127d6d7603717353e251530938e2f58e69e4241220a83de34c6a34531dbc8a2d9fab4bf1ef01000000',
+                              'ff043587cf000000000000000000496e2dc110ea22d9eccc4cf544073593cbd4cd8bd9cdbb990cfa4be8a1bc3735037fe33cf2c12ca4669a262c753da553af507c45776029d1373b36d995a5d1e3df01000000',
+                              '03f0e6194aadb6eb52d11e1f677af21251cda80a24d409230df6f94c4b40308938'],
+                'address': '2N5JTUQ7VJ3XBYh7LmK8Uuhs72UmJGSYcdE',
+                'num_sig': 2,
+                'pubkeys': ['024e539282253ccc288f93966e94fecb637f9491718f1c573ced10aa052fea939a',
+                            '03de64029a56a6a9fb78c8b8f030fc557db85a4f47d1278e556081cd7b2ca381f9',
+                            '03f0e6194aadb6eb52d11e1f677af21251cda80a24d409230df6f94c4b40308938'],
+                'type': 'p2sh',
+                'prevout_n': 1
+            }],
+            'lockTime': 0,
+            'version': 1,
+            'outputs': [{
+                'prevout_n': 0,
+                'scriptPubKey': '76a914b6d22863dfffe257f72ed5ad6daaef8ba970139e88ac',
+                'type': 0,
+                'value': 10000000,
+                'address': 'mxBd2z6kJG48EJpi7oVZ5SWoKWMeJuJHsV'
+            }, {
+                'prevout_n': 1,
+                'scriptPubKey': 'a9140192877a30ab29b73abda5549bbb0a8db01d081287',
+                'type': 0,
+                'value': 79993200,
+                'address': '2MsPYCWAYtRTPZWMQvX1ZGYgqoBuGgPF6wn'
+            }]
+        }
+        tx = transaction.Transaction(raw_onesign)
+        self.assertEqual(tx.deserialize(),tx_onesign)
+        self.assertFalse(tx.is_complete())
+
+        # wallet has no tx history, so this should fail
+        with self.assertRaises(transaction.InputValueMissing):
+            self.wallet.sign_transaction(tx, None)
+
+        # the tx that is used as input
+        raw_src = '01000000010144a6dd5efda1f7f54ed7ba5dcce314f44a071ceb330ac3143dc694aeadb43400000000fdfd000047304402201f2e4d4357688201206168bb99de54a433a13d49160a5b5957fea794be5f1e38022021b4c6d146b2bf7374a46c00e1c7331f36ff1ff47afa29e2b9da8132a309b654414830450221009912b21f3ce1bff9fe6aa03d7da020c9b15dab7c311adbfac038193c6705b35402207625260c4f8a106ccee09946baae2c89d588087bc8e49cc9af474904a5f42157414c6952210348d80fbd95e620b150ca0be9a6090b4c98bc29fb32354d8f0b6b783bab24986d21036410bdf162b5695fc4b79368150480f2d0708303db03fcc7d23707c70b6efe2c2103f7412915e5e7fc72d1cf2829533c1557c9bb169bbbe7d4f7520fc69edaf55de453aefeffffff0280969800000000001976a914b6d22863dfffe257f72ed5ad6daaef8ba970139e88ac383d5d050000000017a914843e0387ccbf569be834e12b119eab167b47835d8700000000'
+        srctx = transaction.Transaction(raw_src)
+        self.assertTrue('2N5JTUQ7VJ3XBYh7LmK8Uuhs72UmJGSYcdE' in srctx.get_output_addresses())
+        self.wallet.add_transaction(srctx.txid(),srctx)
+
+        # this fails, issue 169
+        self.wallet.sign_transaction(tx, None)
+        self.assertTrue(tx.is_complete())

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -50,6 +50,9 @@ NO_SIGNATURE = 'ff'
 class SerializationError(Exception):
     """ Thrown when there's a problem deserializing or serializing """
 
+class InputValueMissing(Exception):
+    """ thrown when the value of an input is needed but not present """
+
 class BCDataStream(object):
     def __init__(self):
         self.input = None
@@ -725,7 +728,10 @@ class Transaction:
             outpoint = self.serialize_outpoint(txin)
             preimage_script = self.get_preimage_script(txin)
             scriptCode = var_int(len(preimage_script) / 2) + preimage_script
-            amount = int_to_hex(txin['value'], 8)
+            try:
+                amount = int_to_hex(txin['value'], 8)
+            except KeyError:
+                raise InputValueMissing
             nSequence = int_to_hex(txin.get('sequence', 0xffffffff - 1), 4)
             preimage = nVersion + hashPrevouts + hashSequence + outpoint + scriptCode + amount + nSequence + hashOutputs + nLocktime + nHashType
         else:

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -677,7 +677,7 @@ class Transaction:
             pkh = bitcoin.hash_160(pubkey.decode('hex')).encode('hex')
             return '76a9' + push_script(pkh) + '88ac'
         else:
-            raise TypeError('Unknown txin type', _type)
+            raise TypeError('Unknown txin type', txin['type'])
 
     @classmethod
     def serialize_outpoint(self, txin):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1073,11 +1073,21 @@ class Abstract_Wallet(PrintError):
             tx = Transaction(self.network.synchronous_get(request))
         return tx
 
-    def add_hw_info(self, tx):
-        # add previous tx for hw wallets
+    def add_input_values_to_tx(self, tx):
+        """ add input values to the tx, for signing"""
         for txin in tx.inputs():
-            tx_hash = txin['prevout_hash']
-            txin['prev_tx'] = self.get_input_tx(tx_hash)
+            if 'value' not in txin:
+                inputtx = self.get_input_tx(txin['prevout_hash'])
+                if inputtx is not None:
+                    out_zero, out_addr, out_val = inputtx.outputs()[txin['prevout_n']]
+                    txin['value'] = out_val
+                    txin['prev_tx'] = inputtx   # may be needed by hardware wallets
+
+    def add_hw_info(self, tx):
+        # add previous tx for hw wallets, if not already there
+        for txin in tx.inputs():
+            if 'prev_tx' not in txin:
+                txin['prev_tx'] = self.get_input_tx(txin['prevout_hash'])
         # add output info for hw wallets
         info = {}
         xpubs = self.get_master_public_keys()
@@ -1094,6 +1104,8 @@ class Abstract_Wallet(PrintError):
     def sign_transaction(self, tx, password):
         if self.is_watching_only():
             return
+        # add input values for signing
+        self.add_input_values_to_tx(tx)
         # hardware wallets require extra info
         if any([(isinstance(k, Hardware_KeyStore) and k.can_sign(tx)) for k in self.get_keystores()]):
             self.add_hw_info(tx)


### PR DESCRIPTION
This is an alternative fix for #169. It will also fix the case when a transaction is signed from the command line, when the wallet is online (not when the wallet is offline). This is an alternative to #170, one of the PR's should be chosen.

The large changes are in the tests, the transaction tests have been improved and wallet tests for this issue have been added.

An exception is raised when generating the preimage for signing, if the value of the input is not known.

A new method add_input_values() has been added to the Wallet class which checks a tx and adds the values of the inputs where those values are not already present.