### PR TITLE
Fix portable argument to no longer use the obsolete electrum option n…

### DIFF
--- a/electron-cash
+++ b/electron-cash
@@ -338,7 +338,7 @@ if __name__ == '__main__':
     config_options['cwd'] = os.getcwd()
 
     if config_options.get('portable'):
-        config_options['electrum_path'] = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'electrum_data')
+        config_options['electron_cash_path'] = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'electron_cash_data')
 
     # kivy sometimes freezes when we write to sys.stderr
     set_verbosity(config_options.get('verbose') and config_options.get('gui')!='kivy')


### PR DESCRIPTION
…ame, and to use the correct electron cash option name.