### PR TITLE
Fix to prevent AttributeError on aborted QR input 

### DIFF
--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -260,7 +260,7 @@ class PayToEdit(ScanQRTextEdit):
 
     def qr_input(self):
         data = super(PayToEdit,self).qr_input()
-        if data.startswith("bitcoincash:"):
+        if data and data.startswith("bitcoincash:"):
             self.scan_f(data)
             # TODO: update fee
 


### PR DESCRIPTION
This was actually reported on reddit by someone [here](https://www.reddit.com/r/btc/comments/7iexxm/electron_cash_version_30_is_here_for_windows_and/dqy9rgu/) 

When the QR input window is closed without scanning any valid QR code, the `qr_input` function returns a NoneType object. This change is a quick and simple fix to just prevent the resulting `AttributeError`, as seen here:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/Electron_Cash-3.0-py3.5.egg/electroncash_gui/qt/paytoedit.py", line 263, in qr_input
    if data.startswith("bitcoincash:"):
AttributeError: 'NoneType' object has no attribute 'startswith'
Aborted
```