### PR TITLE
Fix intrapackage import of cashaddr

### DIFF
--- a/lib/address.py
+++ b/lib/address.py
@@ -28,7 +28,7 @@ import hashlib
 import struct
 
 from .enum import Enumeration
-import lib.cashaddr as cashaddr
+from . import cashaddr
 from .networks import NetworkConstants
 
 _sha256 = hashlib.sha256


### PR DESCRIPTION
The original would throw an exception since both address.py and cashaddr.py live in the same directory, namely "lib".