### PR TITLE
Bundle QR scanner with Android app

### DIFF
--- a/gui/kivy/data/java-classes/org/electrum/qr/SimpleScannerActivity.java
+++ b/gui/kivy/data/java-classes/org/electrum/qr/SimpleScannerActivity.java
@@ -1,0 +1,48 @@
+package org.electrum.qr;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.util.Log;
+import android.content.Intent;
+
+import java.util.Arrays;
+
+import me.dm7.barcodescanner.zxing.ZXingScannerView;
+
+import com.google.zxing.Result;
+import com.google.zxing.BarcodeFormat;
+
+public class SimpleScannerActivity extends Activity implements ZXingScannerView.ResultHandler {
+    private ZXingScannerView mScannerView;
+    final String TAG = "org.electrum.SimpleScannerActivity";
+
+    @Override
+    public void onCreate(Bundle state) {
+        super.onCreate(state);
+        mScannerView = new ZXingScannerView(this);   // Programmatically initialize the scanner view
+        mScannerView.setFormats(Arrays.asList(BarcodeFormat.QR_CODE));
+        setContentView(mScannerView);                // Set the scanner view as the content view
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        mScannerView.setResultHandler(this); // Register ourselves as a handler for scan results.
+        mScannerView.startCamera();          // Start camera on resume
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        mScannerView.stopCamera();           // Stop camera on pause
+    }
+
+    @Override
+    public void handleResult(Result rawResult) {
+        Intent resultIntent = new Intent();
+        resultIntent.putExtra("text", rawResult.getText());
+        resultIntent.putExtra("format", rawResult.getBarcodeFormat().toString());
+        setResult(Activity.RESULT_OK, resultIntent);
+        this.finish();
+    }
+}

--- a/gui/kivy/main_window.py
+++ b/gui/kivy/main_window.py
@@ -390,42 +390,18 @@ class ElectrumWindow(App):
         from jnius import autoclass
         from android import activity
         PythonActivity = autoclass('org.kivy.android.PythonActivity')
+        SimpleScannerActivity = autoclass("org.electrum.qr.SimpleScannerActivity")
         Intent = autoclass('android.content.Intent')
-        intent = Intent("com.google.zxing.client.android.SCAN")
-        intent.putExtra("SCAN_MODE", "QR_CODE_MODE")
+        intent = Intent(PythonActivity.mActivity, SimpleScannerActivity)
         def on_qr_result(requestCode, resultCode, intent):
-            if requestCode == 0:
-                if resultCode == -1: # RESULT_OK:
-                    contents = intent.getStringExtra("SCAN_RESULT")
-                    if intent.getStringExtra("SCAN_RESULT_FORMAT") == 'QR_CODE':
-                        on_complete(contents)
-                    else:
-                        self.show_error("wrong format " + intent.getStringExtra("SCAN_RESULT_FORMAT"))
+            if resultCode == -1:  # RESULT_OK:
+                #  this doesn't work due to some bug in jnius:
+                # contents = intent.getStringExtra("text")
+                String = autoclass("java.lang.String")
+                contents = intent.getStringExtra(String("text"))
+                on_complete(contents)
         activity.bind(on_activity_result=on_qr_result)
-        try:
-            PythonActivity.mActivity.startActivityForResult(intent, 0)
-        except:
-            self.show_error(_('Could not start Barcode Scanner.') + ' ' + _('Please install the Barcode Scanner app from ZXing'))
-
-    def scan_qr_zxing(self, on_complete):
-        # uses zxing embedded lib
-        if platform != 'android':
-            return
-        from jnius import autoclass
-        from android import activity
-        PythonActivity = autoclass('org.kivy.android.PythonActivity')
-        IntentIntegrator = autoclass('com.google.zxing.integration.android.IntentIntegrator')
-        integrator = IntentIntegrator(PythonActivity.mActivity)
-        def on_qr_result(requestCode, resultCode, intent):
-            if requestCode == 0:
-                if resultCode == -1: # RESULT_OK:
-                    contents = intent.getStringExtra("SCAN_RESULT")
-                    if intent.getStringExtra("SCAN_RESULT_FORMAT") == 'QR_CODE':
-                        on_complete(contents)
-                    else:
-                        self.show_error("wrong format " + intent.getStringExtra("SCAN_RESULT_FORMAT"))
-        activity.bind(on_activity_result=on_qr_result)
-        integrator.initiateScan()
+        PythonActivity.mActivity.startActivityForResult(intent, 0)
 
     def do_share(self, data, title):
         if platform != 'android':

--- a/gui/kivy/tools/buildozer.spec
+++ b/gui/kivy/tools/buildozer.spec
@@ -52,7 +52,7 @@ fullscreen = False
 #
 
 # (list) Permissions
-android.permissions = INTERNET, WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE
+android.permissions = INTERNET, WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE, CAMERA
 # (int) Android API to use
 #android.api = 14
 
@@ -86,7 +86,11 @@ android.ndk_path = /opt/crystax-ndk-10.3.2
 
 # (list) List of Java files to add to the android project (can be java or a
 # directory containing the files)
-#android.add_src =
+android.add_src = gui/kivy/data/java-classes/
+
+android.gradle_dependencies = me.dm7.barcodescanner:zxing:1.9.8
+
+android.add_activities = org.electrum.qr.SimpleScannerActivity
 
 # (str) python-for-android branch to use, if not master, useful to try
 # not yet merged features.


### PR DESCRIPTION
This integrates the QR code scanner into the android app. It uses [dm77/barcodescanner](https://github.com/dm77/barcodescanner) from Maven Central, which in turn pulls the relevant parts of zxing into the project.

Pyjnius proved to be quite stubborn in that it crashed whenever a string was passed as an argument but some creative casting prevents that.

The resulting APK file is only marginally larger (<+1MB).

It doesn't look too spectacular but it works (screenshots from the Electrum app):

![screenshot_20171229-231317](https://user-images.githubusercontent.com/598790/34448605-4a565c88-ecef-11e7-9f4f-d157c0c11858.png)
![screenshot_20171229-231310](https://user-images.githubusercontent.com/598790/34448610-4b861472-ecef-11e7-990f-7a2f0f6dd702.png)

This depends on kivy/python-for-android#1213 and kivy/buildozer#612. If you want to test it, merge both and run `rm -rf .buildozer/android/platform/build/{build,dists}` before building.

FYI: I already sent this as spesmilo/electrum#3624 to Electrum.

Closes: #286