### PR TITLE
Fix testnet

### DIFF
--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -350,14 +350,6 @@ class Blockchain(util.PrintError):
         prior = self.read_header(height - 1)
         bits = prior['bits']
 
-        if NetworkConstants.TESTNET:
-            # testnet 20 minute rule
-            if height % 2016 != 0 and header['timestamp'] - prior['timestamp'] > 20*60:
-                return MAX_BITS
-            # This block didn't adjust properly
-            if height == 1199520:
-                return MAX_BITS
-
         #NOV 13 HF DAA
 
         prevheight = height -1
@@ -365,6 +357,11 @@ class Blockchain(util.PrintError):
 
         #if (daa_mtp >= 1509559291):  #leave this here for testing
         if (daa_mtp >= 1510600000):
+
+            if NetworkConstants.TESTNET:
+                # testnet 20 minute rule
+                if header['timestamp'] - prior['timestamp'] > 20*60:
+                    return MAX_BITS
 
             # determine block range
             daa_starting_height=self.get_suitable_block_height(prevheight-144)
@@ -400,6 +397,9 @@ class Blockchain(util.PrintError):
             return self.get_new_bits(height)
 
         if NetworkConstants.TESTNET:
+            # testnet 20 minute rule
+            if header['timestamp'] - prior['timestamp'] > 20*60:
+                return MAX_BITS
             return self.read_header(height // 2016 * 2016)['bits']
 
         # bitcoin cash EDA

--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -27,8 +27,7 @@ import threading
 
 
 from . import util
-from .networks import (NetworkConstants, BITCOIN_CASH_FORK_BLOCK_HEIGHT,
-                       BITCOIN_CASH_FORK_BLOCK_HASH)
+from .networks import NetworkConstants
 from .bitcoin import *
 
 class VerifyError(Exception):
@@ -193,9 +192,8 @@ class Blockchain(util.PrintError):
         if prev_hash != header.get('prev_block_hash'):
             raise VerifyError("prev hash mismatch: %s vs %s" % (prev_hash, header.get('prev_block_hash')))
         # checkpoint BitcoinCash fork block
-        if ( header.get('block_height') == BITCOIN_CASH_FORK_BLOCK_HEIGHT and hash_header(header) != BITCOIN_CASH_FORK_BLOCK_HASH and not NetworkConstants.TESTNET ):
+        if (header.get('block_height') == NetworkConstants.BITCOIN_CASH_FORK_BLOCK_HEIGHT and hash_header(header) != NetworkConstants.BITCOIN_CASH_FORK_BLOCK_HASH):
             err_str = "block at height %i is not cash chain fork block. hash %s" % (header.get('block_height'), hash_header(header))
-            self.print_error(err_str)
             raise VerifyError(err_str)
         if bits != header.get('bits'):
             raise VerifyError("bits mismatch: %s vs %s" % (bits, header.get('bits')))

--- a/lib/networks.py
+++ b/lib/networks.py
@@ -25,11 +25,6 @@
 import json
 import os
 
-
-# Bitcoin Cash fork block specification
-BITCOIN_CASH_FORK_BLOCK_HEIGHT = 478559
-BITCOIN_CASH_FORK_BLOCK_HASH = "000000000000000000651ef99cb9fcbe0dadde1d424bd9f15ff20136191a5eec"
-
 def read_json_dict(filename):
     path = os.path.join(os.path.dirname(__file__), filename)
     try:
@@ -38,7 +33,6 @@ def read_json_dict(filename):
     except:
         r = {}
     return r
-
 
 class NetworkConstants:
 
@@ -67,6 +61,10 @@ class NetworkConstants:
         cls.DEFAULT_SERVERS = read_json_dict('servers.json')
         cls.TITLE = 'Electron Cash'
 
+        # Bitcoin Cash fork block specification
+        cls.BITCOIN_CASH_FORK_BLOCK_HEIGHT = 478559
+        cls.BITCOIN_CASH_FORK_BLOCK_HASH = "000000000000000000651ef99cb9fcbe0dadde1d424bd9f15ff20136191a5eec"
+
     @classmethod
     def set_testnet(cls):
         cls.TESTNET = True
@@ -81,6 +79,10 @@ class NetworkConstants:
         cls.DEFAULT_PORTS = {'t':'51001', 's':'51002'}
         cls.DEFAULT_SERVERS = read_json_dict('servers_testnet.json')
         cls.TITLE = 'Electron Cash Testnet'
+
+        # Bitcoin Cash fork block specification
+        cls.BITCOIN_CASH_FORK_BLOCK_HEIGHT = None
+        cls.BITCOIN_CASH_FORK_BLOCK_HASH = None
 
 
 NetworkConstants.set_mainnet()

--- a/lib/servers_testnet.json
+++ b/lib/servers_testnet.json
@@ -1,5 +1,12 @@
 {
-        '180.235.49.196':  {"t":"51001", "s":"51002"},
-        'electrum-testnet-abc.criptolayer.net': {'s': '50112'},
-        'electrontest.cascharia.com': {'s': '51002'},
+    "180.235.49.196": {
+        "t":"51001",
+        "s":"51002"
+    },
+    "electrum-testnet-abc.criptolayer.net": {
+        "s": "50112"
+    },
+    "electrontest.cascharia.com": {
+        "s": "51002"
+    }
 }


### PR DESCRIPTION
Fixes #389 

It's worth mentioning that server `180.235.49.196` seems to be down, and server `electrum-testnet-abc.criptolayer.net` is roughly two and a half weeks behind. Since there are no other testnet servers available, I've left them in for now.

Additionally, block [#1199520](http://tbcc.blockdozer.com/insight/block/00000000aa5a221632243483ae93a8828bb4ee735c91f4c8d16703246b10c6fe) seemingly didn't adjust according to the Nov 13 DAA HF, which I really can't explain. I've hardcoded in the bit verification for now (otherwise it doesn't continue). If anyone has any explanations for this that would be splendid.