### PR TITLE
macOS fixups for building 3.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,15 +93,7 @@ Now, you'll have a dist/Electron-Cash.app, but it won't quite work.  You need to
 
     (cd dist/Electron-Cash.app/Contents/Resources/lib && mv python36.zip z.zip && mkdir python36.zip &&  cd python36.zip && unzip ../z.zip && rm -f ../z.zip ; mv electroncash_plugins plugins.bak ; ln -s ../python3.6/plugins electroncash_plugins && cd ..) 
 
-Next, you'll try and run it but it will complain that it can't find the 'cocoa' plugin. You have to copy everything from::
-
-    /opt/local/libexec/qt5/plugins 
-
-Into a directory called 'qt_plugins' as such::
-
-    dist/Electron-Cash.app/Contents/Resoureces/qt_plugins 
-
-Now, you need to fix the libs copied in the previous step, use this tool from the root level of the sources::
+Next, you'll try and run it but it will complain that it can't find the 'cocoa' plugin. You have to run this script::
 
     contrib/fix_libs_osx.sh
 

--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Do all the stuff listed under 'Development Version' and 'Creating Binaries' abov
 
 Now, you'll have a dist/Electron-Cash.app, but it won't quite work.  You need to do some crazy magic to get python to see the files properly::
 
-    (cd dist/Electron-Cash.app/Contents/Resources/lib && for z in *.zip; do mv $z z.zip && mkdir $z &&  cd $z && unzip -v ../z.zip && rm -f ../z.zip && mv electroncash_plugins plugins.bak && ln -s ../python3.*/plugins electroncash_plugins && cd .. && rm -f z.zip) 
+    (cd dist/Electron-Cash.app/Contents/Resources/lib && mv python36.zip z.zip && mkdir python36.zip &&  cd python36.zip && unzip ../z.zip && rm -f ../z.zip ; mv electroncash_plugins plugins.bak ; ln -s ../python3.6/plugins electroncash_plugins && cd ..) 
 
 Next, you'll try and run it but it will complain that it can't find the 'cocoa' plugin. You have to copy everything from::
 
@@ -101,9 +101,11 @@ Into a directory called 'qt_plugins' as such::
 
     dist/Electron-Cash.app/Contents/Resoureces/qt_plugins 
 
-and then use install_name_tool on each .dylib file to rewrite hard-coded lib names to @rpath/../Frameworks/.  
+Now, you need to fix the libs copied in the previous step, use this tool from the root level of the sources::
 
-If you know what this means, great!  If not, google it (or give up)!
+    contrib/fix_libs_osx.sh
+
+Now, try to run it.  If it doesn't run, create an issue in github.  If it does, great! 
 
 And finally, optionally create a .dmg...
 

--- a/contrib/fix_libs_osx.sh
+++ b/contrib/fix_libs_osx.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+cd dist/Electron-Cash.app/Contents/Resources 
+
+if [ "$?" != "0" ]; then
+	echo "Run setup-release.py py2app first." 
+	exit 1
+fi
+
+if [ ! -e "qt_plugins" ]; then
+	echo
+	echo "Copying qt_plugins.."
+	echo
+	mkdir qt_plugins
+	cp -fpvR /opt/local/libexec/qt5/plugins/* qt_plugins/
+	echo
+	echo "Removing unneeded libs.."
+	echo
+	rm -fvr qt_plugins/Py*Qt5
+	rm -vf qt_plugins/platforms/libqminimal.dylib qt_plugins/platforms/libqoffscreen.dylib
+fi
+
+otool -l qt_plugins/platforms/libqcocoa.dylib  | grep -q '@executable_path/../Frameworks'
+
+if [ "$?" != "0" ]; then
+	echo
+	echo "Adding rpath to libs..."
+	echo
+	find qt_plugins -type f -name \*.dylib -exec install_name_tool -add_rpath '@executable_path/../Frameworks' {} \; -print
+fi
+
+echo
+echo "Rewriting library link paths..."
+echo
+
+for a in qt_plugins/*/*.dylib; do 
+	libs=`otool -L "$a" | cut -f 2  | cut -f 1 -d ' '`
+	for l in $libs; do
+		ending=""
+		if [ x"${l:0:27}" == x"/opt/local/libexec/qt5/lib/" ]; then
+			ending="${l:27}"
+		elif [ x"${l:0:15}" == x"/opt/local/lib/" ]; then
+			ending="${l:15}"
+		fi
+		if [ -n "$ending" ]; then
+			newpath="@rpath/${ending}"
+			echo "${a}: Rewriting $l to $newpath"
+			install_name_tool -change "$l" "$newpath" "$a"
+		fi
+	done
+done
+
+echo
+echo 'Done!'
+

--- a/contrib/make_packages
+++ b/contrib/make_packages
@@ -7,6 +7,18 @@ if [ $? -ne 0 ] ; then echo "Install pip3" ; exit ; fi
 
 rm -fr $contrib/packages/ 
 
-#Install pure python modules in electrum directory
-pip3 install -r $contrib/requirements.txt -t $contrib/packages
+#Install pure python modules in electron directory
+
+# NB: OSX seems to have different requirements -- at least it did for me -Calin
+if [ `uname` == "Darwin" ]; then
+	# try to name pip the Brew way..
+	PIP=`which pip3` 
+	if [ -z "${PIP}" ]; then
+		# nope, maybe MacPorts instead.. hopefully it's pip3
+		PIP=pip
+	fi
+	$PIP install -r $contrib/requirements_osx.txt -t $contrib/packages 
+else
+	pip3 install -r $contrib/requirements.txt -t $contrib/packages 
+fi
 


### PR DESCRIPTION
- Added a shell script to automate rewriting the dynamic loader libpaths: contrib/fix_libs_osx.sh
- Fixed contrib/make_packages to use requirements_osx.txt on Darwin
- Updated README.rst to reflect new contrib/fix_libs_osx.sh 
