### PR TITLE
Fixes electron-env so that it can be run from source.

### DIFF
--- a/electron-env
+++ b/electron-env
@@ -19,6 +19,10 @@ fi
 
 export PYTHONPATH="/usr/local/lib/python3.5/site-packages:$PYTHONPATH"
 
+if [ ! -e ./gui/qt/icons_rc.py ]; then
+    pyrcc5 icons.qrc -o gui/qt/icons_rc.py
+fi
+
 ./electron-cash "$@"
 
 deactivate

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'dnspython',
         'jsonrpclib-pelix',
         'PySocks>=1.6.6',
+        'pyqt5',
     ],
     packages=[
         'electroncash',


### PR DESCRIPTION
- pyqt5 is now distributed as a wheel so it doesn't need to be installed by the package manager.
- ```PYTHONPATH="/usr/local/lib/python3.5/site-packages```" doesn't work on Ubuntu 16.04, python3-qt5 installs in ```/usr/lib/python3/dist-packages```.
- The GUI icons need to be generated for electron-cash to launch.

With this pull request ````electron-env```` works directly after a ```git clone``` provided libqt5 (not pyqt5) libraries are installed.

Tested on Ubuntu 16.04 LTS.