### PR TITLE
Password-protect the JSON RPC interface

### DIFF
--- a/electron-cash
+++ b/electron-cash
@@ -368,7 +368,7 @@ if __name__ == '__main__':
         fd, server = daemon.get_fd_or_server(config)
         if fd is not None:
             plugins = init_plugins(config, config.get('gui', 'qt'))
-            d = daemon.Daemon(config, fd, is_android)
+            d = daemon.Daemon(config, fd, True)
             d.start()
             d.init_gui(config, plugins)
             sys.exit(0)
@@ -389,7 +389,7 @@ if __name__ == '__main__':
                         print_stderr("starting daemon (PID %d)" % pid)
                         sys.exit(0)
                 init_plugins(config, 'cmdline')
-                d = daemon.Daemon(config, fd, is_android)
+                d = daemon.Daemon(config, fd, False)
                 d.start()
                 if config.get('websocket_server'):
                     from electroncash import websockets
@@ -421,7 +421,6 @@ if __name__ == '__main__':
             else:
                 init_plugins(config, 'cmdline')
                 result = run_offline_command(config, config_options)
-
                 # print result
     if isinstance(result, str):
         print_msg(result)

--- a/electron-cash
+++ b/electron-cash
@@ -368,7 +368,7 @@ if __name__ == '__main__':
         fd, server = daemon.get_fd_or_server(config)
         if fd is not None:
             plugins = init_plugins(config, config.get('gui', 'qt'))
-            d = daemon.Daemon(config, fd)
+            d = daemon.Daemon(config, fd, is_android)
             d.start()
             d.init_gui(config, plugins)
             sys.exit(0)
@@ -389,7 +389,7 @@ if __name__ == '__main__':
                         print_stderr("starting daemon (PID %d)" % pid)
                         sys.exit(0)
                 init_plugins(config, 'cmdline')
-                d = daemon.Daemon(config, fd)
+                d = daemon.Daemon(config, fd, is_android)
                 d.start()
                 if config.get('websocket_server'):
                     from electroncash import websockets

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -116,7 +116,7 @@ def get_rpc_credentials(config):
 
 class Daemon(DaemonThread):
 
-    def __init__(self, config, fd, is_android):
+    def __init__(self, config, fd, is_gui):
         DaemonThread.__init__(self)
         self.config = config
         if config.get('offline'):
@@ -130,14 +130,10 @@ class Daemon(DaemonThread):
 
         self.gui = None
         self.wallets = {}
-        if not is_android:
-            # Setup JSONRPC server
-            self.cmd_runner = Commands(self.config, None, self.network)
-            self.init_server(config, fd)
-        else:
-            self.server = None
+        # Setup JSONRPC server
+        self.init_server(config, fd, is_gui)
 
-    def init_server(self, config, fd):
+    def init_server(self, config, fd, is_gui):
         host = config.get('rpchost', '127.0.0.1')
         port = config.get('rpcport', 0)
 
@@ -152,14 +148,17 @@ class Daemon(DaemonThread):
             return
         os.write(fd, bytes(repr((server.socket.getsockname(), time.time())), 'utf8'))
         os.close(fd)
-        server.timeout = 0.1
-        for cmdname in known_commands:
-            server.register_function(getattr(self.cmd_runner, cmdname), cmdname)
-        server.register_function(self.run_cmdline, 'run_cmdline')
-        server.register_function(self.ping, 'ping')
-        server.register_function(self.run_daemon, 'daemon')
-        server.register_function(self.run_gui, 'gui')
         self.server = server
+        server.timeout = 0.1
+        server.register_function(self.ping, 'ping')
+        if is_gui:
+            server.register_function(self.run_gui, 'gui')
+        else:
+            server.register_function(self.run_daemon, 'daemon')
+            self.cmd_runner = Commands(self.config, None, self.network)
+            for cmdname in known_commands:
+                server.register_function(getattr(self.cmd_runner, cmdname), cmdname)
+            server.register_function(self.run_cmdline, 'run_cmdline')
 
     def ping(self):
         return True
@@ -208,12 +207,13 @@ class Daemon(DaemonThread):
     def run_gui(self, config_options):
         config = SimpleConfig(config_options)
         if self.gui:
-            if hasattr(self.gui, 'new_window'):
-                path = config.get_wallet_path()
-                self.gui.new_window(path, config.get('url'))
-                response = "ok"
-            else:
-                response = "error: current GUI does not support multiple windows"
+            #if hasattr(self.gui, 'new_window'):
+            #    path = config.get_wallet_path()
+            #    self.gui.new_window(path, config.get('url'))
+            #    response = "ok"
+            #else:
+            #    response = "error: current GUI does not support multiple windows"
+            response = "error: Electrum GUI already running"
         else:
             response = "Error: Electrum is running in daemon mode. Please stop the daemon first."
         return response

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -28,12 +28,12 @@ import time
 
 # from jsonrpc import JSONRPCResponseManager
 import jsonrpclib
-from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCServer
+from .jsonrpc import VerifyingJSONRPCServer
 
 from .version import PACKAGE_VERSION
 from .network import Network
 from .util import json_decode, DaemonThread
-from .util import print_error
+from .util import print_error, to_string
 from .wallet import Wallet
 from .storage import WalletStorage
 from .commands import known_commands, Commands
@@ -75,7 +75,14 @@ def get_server(config):
         try:
             with open(lockfile) as f:
                 (host, port), create_time = ast.literal_eval(f.read())
-                server = jsonrpclib.Server('http://%s:%d' % (host, port))
+                rpc_user, rpc_password = get_rpc_credentials(config)
+                if rpc_password == '':
+                    # authentication disabled
+                    server_url = 'http://%s:%d' % (host, port)
+                else:
+                    server_url = 'http://%s:%s@%s:%d' % (
+                        rpc_user, rpc_password, host, port)
+                server = jsonrpclib.Server(server_url)
             # Test daemon is running
             server.ping()
             return server
@@ -85,6 +92,26 @@ def get_server(config):
             return None
         # Sleep a bit and try again; it might have just been started
         time.sleep(1.0)
+
+
+def get_rpc_credentials(config):
+    rpc_user = config.get('rpcuser', None)
+    rpc_password = config.get('rpcpassword', None)
+    if rpc_user is None or rpc_password is None:
+        rpc_user = 'user'
+        import ecdsa, base64
+        bits = 128
+        nbytes = bits // 8 + (bits % 8 > 0)
+        pw_int = ecdsa.util.randrange(pow(2, bits))
+        pw_b64 = base64.b64encode(
+            pw_int.to_bytes(nbytes, 'big'), b'-_')
+        rpc_password = to_string(pw_b64, 'ascii')
+        config.set_key('rpcuser', rpc_user)
+        config.set_key('rpcpassword', rpc_password, save=True)
+    elif rpc_password == '':
+        from .util import print_stderr
+        print_stderr('WARNING: RPC authentication is disabled.')
+    return rpc_user, rpc_password
 
 
 class Daemon(DaemonThread):
@@ -110,8 +137,11 @@ class Daemon(DaemonThread):
     def init_server(self, config, fd):
         host = config.get('rpchost', '127.0.0.1')
         port = config.get('rpcport', 0)
+
+        rpc_user, rpc_password = get_rpc_credentials(config)
         try:
-            server = SimpleJSONRPCServer((host, port), logRequests=False)
+            server = VerifyingJSONRPCServer((host, port), logRequests=False,
+                                            rpc_user=rpc_user, rpc_password=rpc_password)
         except Exception as e:
             self.print_error('Warning: cannot initialize RPC server on host', host, e)
             self.server = None

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -116,7 +116,7 @@ def get_rpc_credentials(config):
 
 class Daemon(DaemonThread):
 
-    def __init__(self, config, fd):
+    def __init__(self, config, fd, is_android):
         DaemonThread.__init__(self)
         self.config = config
         if config.get('offline'):
@@ -130,9 +130,12 @@ class Daemon(DaemonThread):
 
         self.gui = None
         self.wallets = {}
-        # Setup JSONRPC server
-        self.cmd_runner = Commands(self.config, None, self.network)
-        self.init_server(config, fd)
+        if not is_android:
+            # Setup JSONRPC server
+            self.cmd_runner = Commands(self.config, None, self.network)
+            self.init_server(config, fd)
+        else:
+            self.server = None
 
     def init_server(self, config, fd):
         host = config.get('rpchost', '127.0.0.1')

--- a/lib/jsonrpc.py
+++ b/lib/jsonrpc.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+#
+# Electrum - lightweight Bitcoin client
+# Copyright (C) 2018 Thomas Voegtlin
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCServer, SimpleJSONRPCRequestHandler
+from base64 import b64decode
+import time
+
+from . import util
+
+
+class RPCAuthCredentialsInvalid(Exception):
+    def __str__(self):
+        return 'Authentication failed (bad credentials)'
+
+
+class RPCAuthCredentialsMissing(Exception):
+    def __str__(self):
+        return 'Authentication failed (missing credentials)'
+
+
+class RPCAuthUnsupportedType(Exception):
+    def __str__(self):
+        return 'Authentication failed (only basic auth is supported)'
+
+
+# based on http://acooke.org/cute/BasicHTTPA0.html by andrew cooke
+class VerifyingJSONRPCServer(SimpleJSONRPCServer):
+
+    def __init__(self, *args, rpc_user, rpc_password, **kargs):
+
+        self.rpc_user = rpc_user
+        self.rpc_password = rpc_password
+
+        class VerifyingRequestHandler(SimpleJSONRPCRequestHandler):
+            def parse_request(myself):
+                # first, call the original implementation which returns
+                # True if all OK so far
+                if SimpleJSONRPCRequestHandler.parse_request(myself):
+                    try:
+                        self.authenticate(myself.headers)
+                        return True
+                    except (RPCAuthCredentialsInvalid, RPCAuthCredentialsMissing,
+                            RPCAuthUnsupportedType) as e:
+                        myself.send_error(401, str(e))
+                    except BaseException as e:
+                        import traceback, sys
+                        traceback.print_exc(file=sys.stderr)
+                        myself.send_error(500, str(e))
+                return False
+
+        SimpleJSONRPCServer.__init__(
+            self, requestHandler=VerifyingRequestHandler, *args, **kargs)
+
+    def authenticate(self, headers):
+        if self.rpc_password == '':
+            # RPC authentication is disabled
+            return
+
+        auth_string = headers.get('Authorization', None)
+        if auth_string is None:
+            raise RPCAuthCredentialsMissing()
+
+        (basic, _, encoded) = auth_string.partition(' ')
+        if basic != 'Basic':
+            raise RPCAuthUnsupportedType()
+
+        encoded = util.to_bytes(encoded, 'utf8')
+        credentials = util.to_string(b64decode(encoded), 'utf8')
+        (username, _, password) = credentials.partition(':')
+        if not (util.constant_time_compare(username, self.rpc_user)
+                and util.constant_time_compare(password, self.rpc_password)):
+            time.sleep(0.050)
+            raise RPCAuthCredentialsInvalid()

--- a/lib/util.py
+++ b/lib/util.py
@@ -28,6 +28,7 @@ from datetime import datetime
 from decimal import Decimal
 import traceback
 import threading
+import hmac
 
 from .i18n import _
 
@@ -208,6 +209,13 @@ def json_decode(x):
         return json.loads(x, parse_float=Decimal)
     except:
         return x
+
+
+# taken from Django Source Code
+def constant_time_compare(val1, val2):
+    """Return True if the two strings are equal, False otherwise."""
+    return hmac.compare_digest(to_bytes(val1, 'utf8'), to_bytes(val2, 'utf8'))
+
 
 # decorator that prints execution time
 def profiler(func):


### PR DESCRIPTION
From [spesmilo/electrum #3664](https://github.com/spesmilo/electrum/pull/3664)

* Introduce rpcuser and rpcpassword config variables used to authenticate access to the JSON-RPC server
* If the variables are not set, initialise rpcuser to user, and rpcpassword to a random base64 string with ~128 bits of entropy
* The variables are persisted in the config file on the local filesystem. The config file has 0600 permissions.
* Uses HTTP basic access authentication
