### PR TITLE
Changed default private key export filename to electron-cash-private-keys

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2245,7 +2245,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         e.setReadOnly(True)
         vbox.addWidget(e)
 
-        defaultname = 'electrum-cash-private-keys.csv'
+        defaultname = 'electron-cash-private-keys.csv'
         select_msg = _('Select file to export your private keys to')
         hbox, filename_e, csv_button = filename_field(self, self.config, defaultname, select_msg)
         vbox.addLayout(hbox)


### PR DESCRIPTION
It looked like a bug to me that the default filename was 'electrum-cash-private-keys' rather than 'electron-cash-private-keys'.  This PR fixes that.
