### PR TITLE
Add version warning

### DIFF
--- a/electron-cash
+++ b/electron-cash
@@ -26,6 +26,9 @@
 import os
 import sys
 
+if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 5):
+    raise BaseException("Must be using Python 3.5 or higher")
+
 # from https://gist.github.com/tito/09c42fb4767721dc323d
 import threading
 try:


### PR DESCRIPTION
Resolves #420 

Basically a clearer exception for when a user tries to use a version of python lower than 3.5