### PR TITLE
Add historical price rates

### DIFF
--- a/lib/currencies.json
+++ b/lib/currencies.json
@@ -8,6 +8,27 @@
         "USD",
         "BTC"
     ],
+    "BitcoinAverage": [
+      "AUD",
+      "BRL",
+      "CAD",
+      "CHF",
+      "CNY",
+      "EUR",
+      "GBP",
+      "IDR",
+      "ILS",
+      "MXN",
+      "NOK",
+      "NZD",
+      "PLN",
+      "RON",
+      "RUB",
+      "SEK",
+      "SGD",
+      "USD",
+      "ZAR"
+    ],
     "BtcMarkets": [
         "AUD"
     ],

--- a/lib/exchange_rate.py
+++ b/lib/exchange_rate.py
@@ -90,7 +90,7 @@ class BitcoinAverage(ExchangeBase):
 
     def get_rates(self, ccy):
         json = self.get_json('apiv2.bitcoinaverage.com', '/indices/global/ticker/short')
-        return dict([(r.replace("BTC", ""), Decimal(json[r]['last']))
+        return dict([(r.replace("BCH", ""), Decimal(json[r]['last']))
                      for r in json if r != 'timestamp'])
 
     def history_ccys(self):
@@ -100,7 +100,7 @@ class BitcoinAverage(ExchangeBase):
 
     def historical_rates(self, ccy):
         history = self.get_csv('apiv2.bitcoinaverage.com',
-                               "/indices/global/history/BTC%s?period=alltime&format=csv" % ccy)
+                               "/indices/global/history/BCH%s?period=alltime&format=csv" % ccy)
         return dict([(h['DateTime'][:10], h['Average'])
                      for h in history])
 


### PR DESCRIPTION
Fixes #208, Fixes #435 

Addds historical price rates, which fixes a case where users are unable to select any fiat price rates on both android and desktop.