### PR TITLE
Fix max payment on android

### DIFF
--- a/gui/kivy/main_window.py
+++ b/gui/kivy/main_window.py
@@ -658,7 +658,7 @@ class ElectrumWindow(App):
 
     def get_max_amount(self):
         inputs = self.wallet.get_spendable_coins(None, self.electrum_config)
-        addr = str(self.send_screen.screen.address) or self.wallet.dummy_address()
+        addr = Address.from_string(self.send_screen.screen.address) or self.wallet.dummy_address()
         outputs = [(TYPE_ADDRESS, addr, '!')]
         tx = self.wallet.make_unsigned_transaction(inputs, outputs, self.electrum_config)
         amount = tx.output_value()


### PR DESCRIPTION
Fixes #471 

Fixes an issue where the "max" button on the send form crashed the android app. This was caused by an inproperly formated address failing an assertion, fixed by properly formating it.