### PR TITLE
Fix address formating which caused a failed assertion

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -384,7 +384,7 @@ class Commands:
         out = self.wallet.contacts.resolve(x)
         if out.get('type') == 'openalias' and self.nocheck is False and out.get('validated') is False:
             raise BaseException('cannot verify alias', x)
-        return out['address']
+        return Address.from_string(out['address'])
 
     @command('n')
     def sweep(self, privkey, destination, fee=None, nocheck=False, imax=100):


### PR DESCRIPTION
Fixes #489

It might be better to change `lib/contacts.py` so `resolve()` returns an `Address` object, thoughts @kyuupichan? That might break some stuff, I didn't test it too much.