### PR TITLE
Fix contact address format

### DIFF
--- a/lib/contacts.py
+++ b/lib/contacts.py
@@ -68,7 +68,7 @@ class Contacts(dict):
     def resolve(self, k):
         if Address.is_valid(k):
             return {
-                'address': k,
+                'address': Address.from_string(k),
                 'type': 'address'
             }
         if k in self.keys():
@@ -103,7 +103,7 @@ class Contacts(dict):
                     name = address
                 if not address:
                     continue
-                return address, name, validated
+                return Address.from_string(address), name, validated
 
     def find_regex(self, haystack, needle):
         regex = re.compile(needle)


### PR DESCRIPTION
Fixes #489 

Tales of contacts being broken may have been exagerated. However, I'm confused by what [`lib/contacts.py:74`](https://github.com/fyookball/electrum/blob/44cd7f2b94e34a693e6d7fe93f687ef4ffeb6423/lib/contacts.py#L74) is meant to do. It seems that it will take an address and return it's contact title (which would never happen, because the previous if-statement catches all addresses). I feel like this should take a contact title and return an address.