### PR TITLE
Fix message signing test

### DIFF
--- a/lib/tests/test_bitcoin.py
+++ b/lib/tests/test_bitcoin.py
@@ -79,7 +79,7 @@ class Test_bitcoin(unittest.TestCase):
         self.assertTrue(verify_message(addr1, sig1, msg1))
         self.assertTrue(verify_message(addr2, sig2, msg2))
 
-        self.assertFalse(verify_message(addr1, b'wrong', msg1))
+        self.assertRaises(Exception, verify_message, addr1, b'wrong', msg1)
         self.assertFalse(verify_message(addr1, sig2, msg1))
 
     def test_aes_homomorphic(self):


### PR DESCRIPTION
Fixes #504

Changed the test to expect an `Exception` rather than `False`. This might not be the expected functionality, so `verify_message` might need to be modified.