### PR TITLE
Fixed esoteric storage bug when changing password

### DIFF
--- a/lib/storage.py
+++ b/lib/storage.py
@@ -193,6 +193,7 @@ class WalletStorage(PrintError):
             os.remove(self.path)
             os.rename(temp_path, self.path)
         os.chmod(self.path, mode)
+        self.raw = s
         self.print_error("saved", self.path)
         self.modified = False
 


### PR DESCRIPTION
Hi guys,

In my work on the iOS version, I noticed a subtle bug/quirk in storage.py when changing wallet password.  If the user goes from enabling wallet encryption to disabling it (or vice-versa) the change isn't reflected in WalletStorage.is_encrypted() until the app is restarted.

This is because WalletStorage.is_encrypted checks the 'raw' data from the wallet file to answer the 'is encrypted' question -- but self.raw isn't updated properly when executing set_password(), write(), etc after the user requests to go from encrypted/decrypted to its opposite.

Is encrypted:

```
    def is_encrypted(self):
        try:
            return base64.b64decode(self.raw)[0:4] == b'BIE1'
        except:
            return False
```

How to reproduce:

- Using a wallet that was encrypted and pw protected: Open up the password dialog and tell the dialog you want your wallet to be UNencrypted and password protected.   
- You'll notice the messaging and the internal state of the wallet doesn't get updated properly and the app communicates to the user as if the encrypted/decrypted change didn't take effect. Restarting electron cash makes it actually take effect.

Not sure if this fix really is the best or most elegant -- but it definitely solves the UI glitch for me and doesn't look broken (at least it looks less broken than what was there already).

Thanks a lot and do let me know if you want a more thorough approach!
