### PR TITLE
Fix GPU mode on OSX by adding a key to Info.plist

### DIFF
--- a/contrib/build-osx/osx.spec
+++ b/contrib/build-osx/osx.spec
@@ -91,5 +91,6 @@ app = BUNDLE(exe,
              bundle_identifier=None,
              info_plist = {
                  'NSHighResolutionCapable':'True'
+                 'NSSupportsAutomaticGraphicsSwitching': 'True'
              }
 )

--- a/contrib/build-osx/osx.spec
+++ b/contrib/build-osx/osx.spec
@@ -90,7 +90,7 @@ app = BUNDLE(exe,
              icon=electrum+ICONS_FILE,
              bundle_identifier=None,
              info_plist = {
-                 'NSHighResolutionCapable':'True'
-                 'NSSupportsAutomaticGraphicsSwitching': 'True'
+                 'NSHighResolutionCapable':'True',
+                 'NSSupportsAutomaticGraphicsSwitching':'True'
              }
 )


### PR DESCRIPTION
This is a pet peeve of mine:

On OSX, if you don't have this key in Info.plist, all Qt apps run in "High Performance GPU" mode always -- which is annoying because it eats battery life.

Note that the Electrum team already has this key in their Info.plist.

Nothing special needs to be done for our Qt app to support this key.  By default, with this key present, if the app uses advanced GPU features (OpenGL), it will auto-switch to the high performance mode, and switch back then it's done.  Qt supports this internally.

This key really should only be set to false (default) for apps that maintain very specific OpenGL state and don't want their GPU swapped from under them (such as Mining apps).

It's safe to set to true for our app, and saves tons of battery life on laptops.  

Tested and works.
