### PR TITLE
AppStream metadata (cf Flatpak)

### DIFF
--- a/org.electroncash.ElectronCash.appdata.xml
+++ b/org.electroncash.ElectronCash.appdata.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+	<id>electron-cash.desktop</id>
+	<name>Electron Cash</name>
+	<developer_name>Jonald Fyookball</developer_name>
+	<summary>Lightweight Bitcoin Cash Client</summary>
+	<description>
+		<p>Electron Cash is an SPV wallet for Bitcoin Cash</p>
+		<p>Control your own private keys. Easily back up your wallet with a mnemonic seed phrase. Enjoy high security without downloading the blockchain or running a full node.</p>
+	</description>
+	<metadata_license>CC0-1.0</metadata_license>
+	<project_license>MIT</project_license>
+	<url type="homepage">https://www.electroncash.org/</url>
+	<url type="help">https://github.com/fyookball/electrum/issues?q=is%3Aissue</url>
+	<screenshots>
+		<screenshot type="default">
+			<image type="source">https://www.electroncash.org/images/shot4.png</image>
+			<caption>Main application window</caption>
+		</screenshot>
+	</screenshots>
+	<translation type="gettext">electron-cash</translation>
+	<provides>
+		<binary>electron-cash</binary>
+		<python3>electroncash</python3>
+		<python3>electroncash_gui</python3>
+		<python3>electroncash_plugins</python3>
+	</provides>
+	<update_contact>alexander-fp@ninetailed.ninja</update_contact>
+</component>

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,12 @@ if sys.version_info[:3] < (3, 5, 0):
 data_files = []
 
 if platform.system() in ['Linux', 'FreeBSD', 'DragonFly']:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('--root=', dest='root_path', metavar='dir', default='/')
+    parser.add_argument('--prefix=', dest='prefix_path', metavar='prefix', default=sys.prefix)
     opts, _ = parser.parse_known_args(sys.argv[1:])
-    usr_share = os.path.join(sys.prefix, "share")
-    if not os.access(opts.root_path + usr_share, os.W_OK) and \
-       not os.access(opts.root_path, os.W_OK):
+    usr_share = os.path.join(opts.root_path + opts.prefix_path, "share")
+    if not os.access(usr_share, os.W_OK):
         if 'XDG_DATA_HOME' in os.environ.keys():
             usr_share = os.environ['XDG_DATA_HOME']
         else:

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,13 @@ if platform.system() in ['Linux', 'FreeBSD', 'DragonFly']:
         else:
             usr_share = os.path.expanduser('~/.local/share')
     data_files += [
+        # Menu icon
+        (os.path.join(usr_share, 'icons/hicolor/128x128/apps/'), ['icons/electron-cash.png']),
+        (os.path.join(usr_share, 'pixmaps/'),                    ['icons/electron-cash.png']),
+        # Menu entry
         (os.path.join(usr_share, 'applications/'), ['electron-cash.desktop']),
-        (os.path.join(usr_share, 'pixmaps/'), ['icons/electron-cash.png'])
+        # App stream (store) metadata
+        (os.path.join(usr_share, 'metainfo/'), ['org.electroncash.ElectronCash.appdata.xml']),
     ]
 
 setup(


### PR DESCRIPTION
Hi! I've been using *Electron Cash* (and its predecessor) for a while and am pretty happy with it. Since I'm not terribly happy however with the current Linux distribution and installation procedure of this software, I did an experiment and tried to create a [Flatpak app](https://flatpak.org/) for it ([Downloads](https://storage.ninetailed.ninja/index.php/s/Zd5HxE6myDs386R) / [“Source code”](https://gitlab.com/ntninja/electroncash-flatpak)).
Not sure if you interested at all offering better distribution methods (and I must say I'm not sure I'm totally sold on Flatpak at this point), but if you are we should probably discuss this in an issue or something. :slightly_smiling_face: 

Anyway, this PR just contains some fixes for detecting the system installation path in `./setup.py` and adds [AppStream metadata](https://www.freedesktop.org/software/appstream/docs/) that is mostly used to render your app in app stores. Screenshot:
![Gnome Software with the Flatpak open for installation](https://user-images.githubusercontent.com/246386/38157791-86c3e734-348a-11e8-9c1b-70f3659a5178.png)
This is different from the already available *.desktop*-file in that this information will be shown prior to installation while the later is used post-install to launch the app from application menus and runners.