### PR TITLE
[DO NOT MERGE] Default to XDG Base Directory conforming configuration path for new installations

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -355,7 +355,17 @@ def user_dir():
     if 'ANDROID_DATA' in os.environ:
         return android_check_data_dir()
     elif os.name == 'posix':
-        return os.path.join(os.environ["HOME"], ".electron-cash" )
+        # Prefer XDG Base directory spec based condiguration path, but use the legacy dot-directory
+        # configuration path if user has upgraded from a previous installation
+        xdg_config_home = os.environ.get("XDG_CONFIG_HOME", os.path.join(os.environ["HOME"], ".config"))
+        config_path_modern = os.path.join(xdg_config_home, "electron-cash")
+        config_path_legacy = os.path.join(os.environ["HOME"], ".electron-cash")
+        if os.path.exists(config_path_modern) and os.listdir(config_path_modern):
+            return config_path_modern
+        elif os.path.exists(config_path_legacy) and os.listdir(config_path_legacy):
+            return config_path_legacy
+        else:
+            return config_path_modern
     elif "APPDATA" in os.environ:
         return os.path.join(os.environ["APPDATA"], "ElectronCash")
     elif "LOCALAPPDATA" in os.environ:


### PR DESCRIPTION
This changes the default configuration directory from `~/.electron-cash` to `${XDG_CONFIG_HOME:-${HOME}/.config}/electron-cash` for new installations. Existing installations will continue to use the old directory.

This isn't directly required for the Flatpak I'm currently working on (see #625), but it ensures that the expected directory for app configuration files on Linux/Unix platforms is used. I have tested the code both sandboxed (in Flatpak) and non-sandboxed and it works in both environments and the configuration is, thanks to recent changes to the Flatpak, also shared between both versions.

Also it looks the modified piece of source code is used to determine the default configuration directory  on macOS as well? If so, then neither the previous nor the new default value (after this patch) is correct, as it should default to `~/Library/Application Support/<bundle-id>` there afaik ([Source](https://developer.apple.com/library/content/documentation/General/Conceptual/MOSXAppProgrammingGuide/AppRuntime/AppRuntime.html#//apple_ref/doc/uid/TP40010543-CH2-SW13)).