### PR TITLE
ledger: cashaddr support

### DIFF
--- a/plugins/hw_wallet/qt.py
+++ b/plugins/hw_wallet/qt.py
@@ -42,6 +42,7 @@ class QtHandlerBase(QObject, PrintError):
     passphrase_signal = pyqtSignal(object, object)
     message_signal = pyqtSignal(object, object)
     error_signal = pyqtSignal(object)
+    warning_signal = pyqtSignal(object)
     word_signal = pyqtSignal(object)
     clear_signal = pyqtSignal()
     query_signal = pyqtSignal(object, object)
@@ -52,6 +53,7 @@ class QtHandlerBase(QObject, PrintError):
         super(QtHandlerBase, self).__init__()
         self.clear_signal.connect(self.clear_dialog)
         self.error_signal.connect(self.error_dialog)
+        self.warning_signal.connect(self.warning_dialog)
         self.message_signal.connect(self.message_dialog)
         self.passphrase_signal.connect(self.passphrase_dialog)
         self.word_signal.connect(self.word_dialog)
@@ -91,6 +93,11 @@ class QtHandlerBase(QObject, PrintError):
 
     def show_error(self, msg):
         self.error_signal.emit(msg)
+
+    def show_warning(self, msg):
+        self.done.clear()
+        self.warning_signal.emit(msg)
+        self.done.wait()
 
     def finished(self):
         self.clear_signal.emit()
@@ -155,6 +162,10 @@ class QtHandlerBase(QObject, PrintError):
 
     def error_dialog(self, msg):
         self.win.show_error(msg, parent=self.top_level_window())
+
+    def warning_dialog(self, msg):
+        self.win.show_warning(msg, parent=self.top_level_window())
+        self.done.set()
 
     def clear_dialog(self):
         if self.dialog:


### PR DESCRIPTION
Adds cashaddr support for the ledger wallet nano s and blue, as well as irritates the user to update their firmware/libraries if they have cashaddr enabled.

requirements:
* ledger firmware:      1.4.2
* bitcoin cash app:     1.2.5
* python-btchip:        0.1.27

https://github.com/LedgerHQ/btchip-python/commit/7c6d107d0ec2e55484c39849ff9291167cf41fd0
https://github.com/LedgerHQ/blue-app-btc/commit/74f61cf1014572a001e0b0ab5ec330cc347f713a