### PR TITLE
Provide better information to users importing a 2fa wallet

### DIFF
--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -194,25 +194,29 @@ class ElectrumGui:
         else:
             try:
                 wallet = self.daemon.load_wallet(path, None)
+                if not wallet:
+                    storage = WalletStorage(path, manual_upgrades=True)
+                    wizard = InstallWizard(self.config, self.app, self.plugins, storage)
+                    try:
+                        wallet = wizard.run_and_get_wallet()
+                    except UserCancelled:
+                        pass
+                    except GoBack as e:
+                        print_error('[start_new_window] Exception caught (GoBack)', e)
+                    wizard.terminate()
+                    if not wallet:
+                        return
+                    wallet.start_threads(self.daemon.network)
+                    self.daemon.add_wallet(wallet)
             except BaseException as e:
                 traceback.print_exc(file=sys.stdout)
-                d = QMessageBox(QMessageBox.Warning, _('Error'), 'Cannot load wallet:\n' + str(e))
-                d.exec_()
+                if '2fa' in str(e):
+                    d = QMessageBox(QMessageBox.Warning, _('Error'), '2FA wallets for Bitcoin Cash are currently unsupported by <a href="https://api.trustedcoin.com/#/">TrustedCoin</a>. Follow <a href="https://github.com/fyookball/electrum/issues/41#issuecomment-357468208">this guide</a> in order to recover your funds.')
+                    d.exec_()
+                else:
+                    d = QMessageBox(QMessageBox.Warning, _('Error'), 'Cannot load wallet:\n' + str(e))
+                    d.exec_()
                 return
-            if not wallet:
-                storage = WalletStorage(path, manual_upgrades=True)
-                wizard = InstallWizard(self.config, self.app, self.plugins, storage)
-                try:
-                    wallet = wizard.run_and_get_wallet()
-                except UserCancelled:
-                    pass
-                except GoBack as e:
-                    print_error('[start_new_window] Exception caught (GoBack)', e)
-                wizard.terminate()
-                if not wallet:
-                    return
-                wallet.start_threads(self.daemon.network)
-                self.daemon.add_wallet(wallet)
             w = self.create_window_for_wallet(wallet)
         if uri:
             w.pay_to_URI(uri)


### PR DESCRIPTION
Provide some better information to a user importing a 2fa wallet (directly links to @DarkLordGMS's wonderful guide https://github.com/fyookball/electrum/issues/41#issuecomment-357468208). Probably not as useful as it would have been a few months ago, but better than nothing.

Also fixes #616, as it handles upgrading a 2fa wallet as well.

Issues:
- Only for QT, nothing for CLI
- Doesn't terminate the wizard when you get this error while upgrading a wallet (although it didn't before, and it seems ok)
- The `if '2fa' in str(e)` and/or wrapping everything in a try/catch might be too messy, so suggestions are accepted
