### PR TITLE
Fixes and improvements to the new plugin code

### DIFF
--- a/contrib/package_plugin.py
+++ b/contrib/package_plugin.py
@@ -66,15 +66,15 @@ def write_plugin_archive(metadata, source_package_path, archive_file_path):
         shutil.make_archive(suffixless_path, 'zip', temp_path)
         
     plugin_path = suffixless_path +".zip"
-    hash_md5 = hashlib.md5()
+    hasher = hashlib.sha256()
     with open(plugin_path, "rb") as f:
-        hash_md5.update(f.read())
+        hasher.update(f.read())
 
     base_name = os.path.basename(plugin_path)
-    with open(plugin_path +".md5", "w") as f:
-        f.write("{0} *{1}".format(hash_md5.hexdigest(), base_name))
+    with open(plugin_path +".sha256", "w") as f:
+        f.write("{0} *{1}".format(hasher.hexdigest(), base_name))
 
-    return hash_md5.hexdigest()
+    return hasher.hexdigest()
 
 def write_manifest(metadata, manifest_file_path):
     with open(manifest_file_path, "w") as f:
@@ -109,11 +109,6 @@ def build_manifest(display_name, version, description, minimum_ec_version, packa
     
     return metadata
 
-# A line edit that can be selected and copied, but not edited.
-class XLineEdit(QLineEdit):
-    def keyPressEvent(self, event):
-        event.ignore()
-
 class App(QWidget):
     def __init__(self):
         super().__init__()
@@ -121,8 +116,8 @@ class App(QWidget):
         self.directory_path = None
          
         self.setWindowTitle('Electron Cash Plugin Packager')
-        self.setMinimumWidth(400)
-        self.setMaximumWidth(400)
+        self.setMinimumWidth(450)
+        self.setMaximumWidth(450)
         
         outerVLayout = QVBoxLayout()
         self.setLayout(outerVLayout)
@@ -179,9 +174,9 @@ class App(QWidget):
         outerVLayout.addLayout(buttonsHLayout)
         
         self.closeButton = QPushButton("Close")
-        self.checksumLineEdit = XLineEdit()
-        self.checksumLineEdit.setPlaceholderText("Computed checksum of plugin archive..")
-        self.checksumLineEdit.setMinimumWidth(250)
+        self.checksumLineEdit = QLineEdit()
+        self.checksumLineEdit.setPlaceholderText("Computed SHA256 checksum of plugin archive..")
+        self.checksumLineEdit.setMinimumWidth(350)
         buttonsHLayout = QHBoxLayout()
         buttonsHLayout.addWidget(self.checksumLineEdit)
         buttonsHLayout.addStretch(1)

--- a/gui/qt/external_plugins_window.py
+++ b/gui/qt/external_plugins_window.py
@@ -44,7 +44,7 @@ INSTALL_ERROR_MESSAGES = {
     ExternalPluginCodes.INVALID_MANIFEST_JSON: _("The plugin manifest is not recognized as valid JSON."),
     ExternalPluginCodes.INVALID_MAMIFEST_DISPLAY_NAME: _("The plugin manifest lacks a valid display name."),
     ExternalPluginCodes.INVALID_MAMIFEST_DESCRIPTION: _("The plugin manifest lacks a valid description."),
-    ExternalPluginCodes.INVALID_MAMIFEST_VERSION: _("The plugin manifest lacks a valid vesion."),
+    ExternalPluginCodes.INVALID_MAMIFEST_VERSION: _("The plugin manifest lacks a valid version."),
     ExternalPluginCodes.INVALID_MAMIFEST_MINIMUM_EC_VERSION: _("The plugin manifest lacks a valid minimum Electron Cash version."),
     ExternalPluginCodes.INVALID_MAMIFEST_PACKAGE_NAME: _("The plugin manifest lacks a valid package name."),
 }

--- a/gui/qt/external_plugins_window.py
+++ b/gui/qt/external_plugins_window.py
@@ -40,6 +40,13 @@ INSTALL_ERROR_MESSAGES = {
     ExternalPluginCodes.UNABLE_TO_COPY_FILE: _("It was not possible to copy the plugin archive into Electron Cash's plugin storage location. It was therefore not possible to install it."),
     ExternalPluginCodes.INSTALLED_BUT_FAILED_LOAD: _("The plugin is installed, but in the process of enabling and loading it, an error occurred. Restart Electron Cash and try again, or uninstall it and report it to it's developers."),
     ExternalPluginCodes.INCOMPATIBLE_VERSION: _("The plugin is targeted at a later version of Electron Cash."),
+    ExternalPluginCodes.INCOMPATIBLE_ZIP_FORMAT: _("The plugin archive is not recognized as a valid Zip file."),
+    ExternalPluginCodes.INVALID_MANIFEST_JSON: _("The plugin manifest is not recognized as valid JSON."),
+    ExternalPluginCodes.INVALID_MAMIFEST_DISPLAY_NAME: _("The plugin manifest lacks a valid display name."),
+    ExternalPluginCodes.INVALID_MAMIFEST_DESCRIPTION: _("The plugin manifest lacks a valid description."),
+    ExternalPluginCodes.INVALID_MAMIFEST_VERSION: _("The plugin manifest lacks a valid vesion."),
+    ExternalPluginCodes.INVALID_MAMIFEST_MINIMUM_EC_VERSION: _("The plugin manifest lacks a valid minimum Electron Cash version."),
+    ExternalPluginCodes.INVALID_MAMIFEST_PACKAGE_NAME: _("The plugin manifest lacks a valid package name."),
 }
 
 use_tree_widget = True
@@ -47,7 +54,7 @@ use_tree_widget = True
 class FixedCheckBox(QCheckBox):
     def mousePressEvent(self, event):
         event.ignore()
-        
+
     def mouseReleaseEvent(self, event):
         event.ignore()
 
@@ -77,7 +84,7 @@ class ExternalPluginsPreviewDialog(WindowModalDialog):
         self.supportedInterfacesLabel = QLabel(_("Integration"))
         self.supportedInterfacesLabel.setAlignment(Qt.AlignLeft | Qt.AlignTop)
         self.metadataFormLayout.addRow(self.supportedInterfacesLabel, self.supportedInterfacesLayout)
-        
+
         self.qtInterfaceCheckBox = FixedCheckBox("User interface.")
         self.supportedInterfacesLayout.addWidget(self.qtInterfaceCheckBox)
         self.cmdLineInterfaceCheckBox = FixedCheckBox("Command-line.")
@@ -91,7 +98,7 @@ class ExternalPluginsPreviewDialog(WindowModalDialog):
         self.checksumLabel = QLabel()
         self.checksumLabel.setAlignment(Qt.AlignRight)
         self.checksumLabel.setToolTip(_("If the official source for this plugin has a checksum for this plugin, ensure that the value shown here is the same."))
-        securityFormLayout.addRow(_("Archive MD5 Checksum"), self.checksumLabel)
+        securityFormLayout.addRow(_("Archive SHA256 Checksum"), self.checksumLabel)
 
         groupBox = QGroupBox(_("Security"))
         groupBox.setLayout(securityFormLayout)
@@ -122,26 +129,26 @@ class ExternalPluginsPreviewDialog(WindowModalDialog):
         self.versionLabel.setText(_("Unavailable."))
         self.descriptionLabel.setText(_("Unavailable."))
         self.checksumLabel.setText(_("Unavailable."))
-            
+
         self.refresh_plugin(plugin_path)
         self.refresh_ui()
 
     def refresh_plugin(self, plugin_path):
         self.plugin_path = plugin_path
-        
-        plugin_manager = self.main_window.gui_object.plugins
-        self.plugin_metadata = plugin_manager.get_metadata_from_external_plugin_zip_file(plugin_path)
 
-        hash_md5 = hashlib.md5()
+        plugin_manager = self.main_window.gui_object.plugins
+        self.plugin_metadata, error_code = plugin_manager.get_metadata_from_external_plugin_zip_file(plugin_path)
+
+        hasher = hashlib.sha256()
         with open(plugin_path, "rb") as f:
-            hash_md5.update(f.read())
-        self.checksumLabel.setText(hash_md5.hexdigest())
-        
+            hasher.update(f.read())
+        self.checksumLabel.setText(hasher.hexdigest())
+
         self.pluginNameLabel.setText(self.plugin_metadata["display_name"])
         if "version" in self.plugin_metadata:
             self.versionLabel.setText(str(self.plugin_metadata["version"]))
         self.descriptionLabel.setText(self.plugin_metadata["description"])
-        
+
         available_for = self.plugin_metadata.get("available_for", [])
         self.qtInterfaceCheckBox.setChecked("qt" in available_for)
         self.cmdLineInterfaceCheckBox.setChecked("cmdline" in available_for)
@@ -161,7 +168,7 @@ class ExternalPluginsPreviewDialog(WindowModalDialog):
 
     def is_plugin_valid(self):
         return self.plugin_metadata is not None
-        
+
     def on_liability_toggled(self):
         self.refresh_ui()
 
@@ -220,7 +227,7 @@ class ExternalPluginsDialog(WindowModalDialog, MessageBoxMixin):
         # Do an initial prime of the UI based on current state. We share the same
         # logic as updates following changes in state, in order to be consistent.
         self.refresh_ui()
-        
+
     def refresh_ui(self):
         self.pluginsList.refresh_ui()
         selected_id = self.pluginsList.get_selected_key()
@@ -253,23 +260,29 @@ class ExternalPluginsDialog(WindowModalDialog, MessageBoxMixin):
             selected_file_paths = d.selectedFiles()
             if len(selected_file_paths):
                 self.show_install_plugin_preview_dialog(selected_file_paths[0])
-            
+
     def show_install_plugin_preview_dialog(self, file_path):
-        self.installWarningDialog = d = ExternalPluginsPreviewDialog(self, self.main_window, _("Plugin Preview"), file_path)
-        d.exec_()
+        plugin_manager = self.main_window.gui_object.plugins
+        # We need to poll the file to see if it is valid.
+        plugin_metadata, error_code = plugin_manager.get_metadata_from_external_plugin_zip_file(file_path)
+        if plugin_metadata is not None:
+            self.installWarningDialog = d = ExternalPluginsPreviewDialog(self, self.main_window, _("Plugin Preview"), file_path)
+            d.exec_()
+        else:
+            self.show_error(INSTALL_ERROR_MESSAGES.get(error_code, _("Unexpected error %d") % error_code))
 
     def install_plugin_confirmed(self, plugin_archive_path):
         plugin_manager = self.main_window.gui_object.plugins
         result_code = plugin_manager.install_external_plugin(plugin_archive_path)
         if result_code != ExternalPluginCodes.SUCCESS:
-            self.show_error(INSTALL_ERROR_MESSAGES[result_code])
+            self.show_error(INSTALL_ERROR_MESSAGES.get(result_code, _("Unexpected error %d") % error_code))
         else:
             run_hook('init_qt', self.main_window.gui_object)
         self.refresh_ui()
 
     def on_uninstall_plugin(self):
         package_name = self.pluginsList.get_selected_key()
-        if self.show_warning(_("Are you sure you want to uninstall the selected plugin?")):
+        if self.question(_("Are you sure you want to uninstall the selected plugin?")):
             plugin_manager = self.main_window.gui_object.plugins
             plugin_manager.uninstall_external_plugin(package_name)
             self.refresh_ui()
@@ -307,7 +320,7 @@ class ExternalPluginTable(QTableWidget):
         QTableWidget.__init__(self)
 
         self.setAcceptDrops(True)
-        
+
         self.setSelectionMode(QAbstractItemView.SingleSelection)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.setSortingEnabled(False)
@@ -322,7 +335,7 @@ class ExternalPluginTable(QTableWidget):
         self.itemSelectionChanged.connect(self.on_item_selection_changed)
 
         self.row_keys = []
-        
+
     def get_file_path_from_dragdrop_event(self, event):
         mimeData = event.mimeData()
         if mimeData.hasUrls():

--- a/gui/qt/external_plugins_window.py
+++ b/gui/qt/external_plugins_window.py
@@ -59,8 +59,8 @@ class ExternalPluginsPreviewDialog(WindowModalDialog):
         self.main_window = main_window
         self.plugin_dialog = plugin_dialog
 
-        self.setMinimumWidth(400)
-        self.setMaximumWidth(400)
+        self.setMinimumWidth(600)
+        self.setMaximumWidth(600)
 
         vbox = QVBoxLayout()
         self.setLayout(vbox)

--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -296,7 +296,7 @@ class Plugins(DaemonThread):
             return None, ExternalPluginCodes.MISSING_MANIFEST
 
         # START: json.loads for Python < 3.6 does not support bytes.  Delete this when we upgrade to 3.6.
-        if True or not (sys.version_info.major > 3 or sys.version_info.major == 3 and sys.version_info.minor >= 6):
+        if not (sys.version_info.major > 3 or sys.version_info.major == 3 and sys.version_info.minor >= 6):
             # Copied from `json\__init__.py` in the 3.6 standard library.
             # Python standard license applies to this if statement.
             if isinstance(metadata_text, (bytes, bytearray)):

--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -23,12 +23,13 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from collections import namedtuple
+import codecs
 import traceback
-import sys
 import os
 import imp
 import json
 import pkgutil
+import sys
 import time
 import shutil
 import threading
@@ -293,6 +294,42 @@ class Plugins(DaemonThread):
         except OSError:
             self.print_error("missing 'manifest.json' (zip plugin %s)" % file_name)
             return None, ExternalPluginCodes.MISSING_MANIFEST
+
+        # START: json.loads for Python < 3.6 does not support bytes.  Delete this when we upgrade to 3.6.
+        if True or not (sys.version_info.major > 3 or sys.version_info.major == 3 and sys.version_info.minor >= 6):
+            # Copied from `json\__init__.py` in the 3.6 standard library.
+            # Python standard license applies to this if statement.
+            if isinstance(metadata_text, (bytes, bytearray)):
+                def detect_encoding(b):
+                    bstartswith = b.startswith
+                    if bstartswith((codecs.BOM_UTF32_BE, codecs.BOM_UTF32_LE)):
+                        return 'utf-32'
+                    if bstartswith((codecs.BOM_UTF16_BE, codecs.BOM_UTF16_LE)):
+                        return 'utf-16'
+                    if bstartswith(codecs.BOM_UTF8):
+                        return 'utf-8-sig'
+
+                    if len(b) >= 4:
+                        if not b[0]:
+                            # 00 00 -- -- - utf-32-be
+                            # 00 XX -- -- - utf-16-be
+                            return 'utf-16-be' if b[1] else 'utf-32-be'
+                        if not b[1]:
+                            # XX 00 00 00 - utf-32-le
+                            # XX 00 00 XX - utf-16-le
+                            # XX 00 XX -- - utf-16-le
+                            return 'utf-16-le' if b[2] or b[3] else 'utf-32-le'
+                    elif len(b) == 2:
+                        if not b[0]:
+                            # 00 XX - utf-16-be
+                            return 'utf-16-be'
+                        if not b[1]:
+                            # XX 00 - utf-16-le
+                            return 'utf-16-le'
+                    # default
+                    return 'utf-8'            
+                metadata_text = metadata_text.decode(detect_encoding(metadata_text), 'surrogatepass')
+        # END
 
         try:
             metadata = json.loads(metadata_text)

--- a/lib/util.py
+++ b/lib/util.py
@@ -631,25 +631,6 @@ def setup_thread_excepthook():
 
     threading.Thread.__init__ = init
 
-def is_same_or_later_version(that_version, this_version):
-    """
-    Reflects `that_version` is same or later than `this_version`.
-    """
-    if type(that_version) is str:
-        that_version = versiontuple(that_version)
-    if type(this_version) is str:
-        this_version = versiontuple(this_version)
-    dimension_count = max(len(this_version), len(that_version))
-    for i in range(dimension_count):
-        that_value = that_version[i] if i < len(that_version) else 0
-        this_value = this_version[i] if i < len(this_version) else 0
-        # Either we need to go more precise.
-        if that_value == this_value:
-            continue
-        # Or this is the defining level.
-        return that_value > this_value
-    # Must be the same.
-    return True
 
 def versiontuple(v):
     return tuple(map(int, (v.split("."))))


### PR DESCRIPTION
Commit 1 relating to review by Marcel:

* Remove stale comment about external plugin package name.
* Remove versiontuple comparison function, as tuples can be compared directly for the same effect.
* Add kivy ui support to plugin packaging script. 
* Add standard .md5 file writing to accompany zip file writing in plugin packaging script.
* Increase width of plugin preview window, as it is reported the liability checkbox has it's text cut off on some OS.

Commit 2 fixing more identified polish areas:

* Change checksum function from md5 to sha256.
* Change plugin uninstall confirm dialog from a non-cancellable warning dialog to a Yes/No question dialog.
* Add better display of errors when a plugin the user is trying to add is found to be invalid (more error messages, fallback on error code if no error message).

Commit 3:

* Fix spelling of one word.

Commit 4:

* Fix bug discovered by Jonald where `json.loads` was called with a `bytes` object, which worked for me and in testing because I was using Python 3.6 as were any testers.  This is now converted to a `str` object which will be loaded as json in Python 3.5.