### PR TITLE
Fixes for Android wallet dialog

### DIFF
--- a/gui/kivy/uix/ui_screens/status.kv
+++ b/gui/kivy/uix/ui_screens/status.kv
@@ -1,5 +1,5 @@
 Popup:
-    title: "Electrum"
+    title: "Electron Cash"
     confirmed: 0
     unconfirmed: 0
     unmatured: 0

--- a/gui/kivy/uix/ui_screens/status.kv
+++ b/gui/kivy/uix/ui_screens/status.kv
@@ -68,6 +68,8 @@ Popup:
             Button:
                 size_hint: 0.5, None
                 height: '48dp'
+                background_normal: ''
+                background_color: 1, .4, .3412, 1
                 text: _('Delete')
                 on_release:
                     root.dismiss()

--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -284,7 +284,7 @@ class NetworkChoiceLayout(object):
         # Blockchain Tab
         grid = QGridLayout(blockchain_tab)
         msg =  ' '.join([
-            _("Electrum connects to several nodes in order to download block headers and find out the longest blockchain."),
+            _("Electron Cash connects to several nodes in order to download block headers and find out the longest blockchain."),
             _("This blockchain is used to verify the transactions sent by your transaction server.")
         ])
         self.status_label = QLabel('')


### PR DESCRIPTION
1.  Correct title name
2.  Make delete button a red one to warn users "this is a dangerous button to tap"
     The red color (1, .4, .3412, 1) in (r, g, b, a) is equivalent to the red negative value (#FF6657) in transaction history list.
 
