### PR TITLE
Fix #683, if a user tries to preview a transaction without any local …

### DIFF
--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1002,7 +1002,10 @@ class Abstract_Wallet(PrintError):
         # Sort the inputs and outputs deterministically
         tx.BIP_LI01_sort()
         # Timelock tx to current height.
-        tx.locktime = self.get_local_height()
+        locktime = self.get_local_height()
+        if locktime == -1: # We have no local height data (no headers synced).
+            locktime = 0
+        tx.locktime = locktime
         run_hook('make_unsigned_transaction', self, tx)
         return tx
 


### PR DESCRIPTION
…state (headers, etc) the local height will be -1, and when used as the locktime will choke the hex serialisation.  The change made sets the locktime to 0, if the local blockheight is -1, which should mean the tx can be broadcast and mined immediately.