### PR TITLE
Fix #676. This gethostbyname unicode problem occurs on Windows for Py…

### DIFF
--- a/electron-cash
+++ b/electron-cash
@@ -30,7 +30,7 @@ import os
 
 import sys
 
-if sys.version_info < (3, 5):
+if sys.version_info < (3, 5, 2):
     sys.exit("Error: Must be using Python 3.5 or higher")
 
 # from https://gist.github.com/tito/09c42fb4767721dc323d


### PR DESCRIPTION
…thon versions less than 3.5.2.  This change forces a requirement of Python 3.5.2, which is already used in Windows cross-platform builds by Jonald.