### PR TITLE
Fix #662. Catch OSError when printing exception, so that the UI still…

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -296,7 +296,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
     def on_error(self, exc_info):
         if not isinstance(exc_info[1], UserCancelled):
-            traceback.print_exception(*exc_info)
+            try:
+                traceback.print_exception(*exc_info)
+            except OSError:
+                # Issue #662, user got IO error.
+                # We want them to still get the error displayed to them.
+                pass
             self.show_error(str(exc_info[1]))
 
     def on_network(self, event, *args):


### PR DESCRIPTION
… displays it to the user.