### PR TITLE
Fix #661. The input values were added to the exported tx json

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -296,12 +296,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
     def on_error(self, exc_info):
         if not isinstance(exc_info[1], UserCancelled):
-            try:
-                traceback.print_exception(*exc_info)
-            except OSError:
-                # Issue #662, user got IO error.
-                # We want them to still get the error displayed to them.
-                pass 
+            traceback.print_exception(*exc_info)
             self.show_error(str(exc_info[1]))
 
     def on_network(self, event, *args):

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -296,7 +296,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
     def on_error(self, exc_info):
         if not isinstance(exc_info[1], UserCancelled):
-            traceback.print_exception(*exc_info)
+            try:
+                traceback.print_exception(*exc_info)
+            except OSError:
+                # Issue #662, user got IO error.
+                # We want them to still get the error displayed to them.
+                pass 
             self.show_error(str(exc_info[1]))
 
     def on_network(self, event, *args):

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2205,7 +2205,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         file_content = file_content.strip()
         tx_file_dict = json.loads(str(file_content))
         tx = self.tx_from_text(file_content)
-        if len(tx_file_dict['input_values']) >= len(tx.inputs()):
+        # Older saved transaction do not include this key.
+        if 'input_values' in tx_file_dict and len(tx_file_dict['input_values']) >= len(tx.inputs()):
             for i in range(len(tx.inputs())):
                 tx._inputs[i]['value'] = tx_file_dict['input_values'][i]
         return tx


### PR DESCRIPTION
in commit 922b133, and are looked for when tx are read from files.  Given the values were added for offline signing, and were not present otherwise, this fix handles their non-presence on tx file import.

Flatten this commit on merge, as it drags along a reverted fix to another issue.