### PR TITLE
Fix #659. While the user is pondering entering their password...

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -296,12 +296,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
     def on_error(self, exc_info):
         if not isinstance(exc_info[1], UserCancelled):
-            try:
-                traceback.print_exception(*exc_info)
-            except OSError:
-                # Issue #662, user got IO error.
-                # We want them to still get the error displayed to them.
-                pass 
+            traceback.print_exception(*exc_info)
             self.show_error(str(exc_info[1]))
 
     def on_network(self, event, *args):

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -296,7 +296,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
     def on_error(self, exc_info):
         if not isinstance(exc_info[1], UserCancelled):
-            traceback.print_exception(*exc_info)
+            try:
+                traceback.print_exception(*exc_info)
+            except OSError:
+                # Issue #662, user got IO error.
+                # We want them to still get the error displayed to them.
+                pass 
             self.show_error(str(exc_info[1]))
 
     def on_network(self, event, *args):

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -248,8 +248,10 @@ class Daemon(DaemonThread):
         return self.wallets.get(path)
 
     def stop_wallet(self, path):
-        wallet = self.wallets.pop(path)
-        wallet.stop_threads()
+        # Issue #659 wallet may already be stopped.
+        if path in self.wallets:
+            wallet = self.wallets.pop(path)
+            wallet.stop_threads()
 
     def run_cmdline(self, config_options):
         password = config_options.get('password')


### PR DESCRIPTION
While the user is pondering entering their password to delete their wallet, the wallet is stopped in the daemon. This allows the deletion to proceed without erroring if the wallet is already stopped in the daemon.

Flatten this commit on merge, as it drags along a reverted fix to another issue.