### PR TITLE
Minimum python version of 3.5.2 in all checks.  Include Python versio…

### DIFF
--- a/electron-cash
+++ b/electron-cash
@@ -30,8 +30,8 @@ import os
 
 import sys
 
-if sys.version_info < (3, 5):
-    sys.exit("Error: Must be using Python 3.5 or higher")
+if sys.version_info < (3, 5, 2):
+    sys.exit("Error: Must be using Python 3.5.2 or higher")
 
 # from https://gist.github.com/tito/09c42fb4767721dc323d
 import threading

--- a/gui/qt/exception_window.py
+++ b/gui/qt/exception_window.py
@@ -47,6 +47,7 @@ issue_template = """<h2>Traceback</h2>
 <h2>Additional information</h2>
 <ul>
   <li>Electron Cash version: {app_version}</li>
+  <li>Python version: {python_version}</li>
   <li>Operating system: {os}</li>
   <li>Wallet type: {wallet_type}</li>
   <li>Locale: {locale}</li>
@@ -146,6 +147,7 @@ class Exception_Window(QWidget):
     def get_additional_info(self):
         args = {
             "app_version": PACKAGE_VERSION,
+            "python_version": sys.version,
             "os": platform.platform(),
             "wallet_type": "unknown",
             "locale": locale.getdefaultlocale()[0],

--- a/setup-release.py
+++ b/setup-release.py
@@ -21,8 +21,8 @@ from lib.version import PACKAGE_VERSION as version
 name = "Electron-Cash"
 mainscript = 'electron-cash'
 
-if sys.version_info[:3] < (3, 0, 0):
-    print_error("Error: " + name + " requires Python version >= 3.0.0...")
+if sys.version_info[:3] < (3, 5, 2):
+    print_error("Error: " + name + " requires Python version >= 3.5.2...")
     sys.exit(1)
 
 if sys.platform == 'darwin':

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ with open('contrib/requirements/requirements-hw.txt') as f:
 
 version = imp.load_source('version', 'lib/version.py')
 
-if sys.version_info[:3] < (3, 5, 0):
-    sys.exit("Error: Electron Cash requires Python version >= 3.5.0...")
+if sys.version_info[:3] < (3, 5, 2):
+    sys.exit("Error: Electron Cash requires Python version >= 3.5.2...")
 
 data_files = []
 


### PR DESCRIPTION
…n string in exceptions reported to the crash server (reports still make it to the issues list, despite no changes to the crash server to handle the extra data).