### PR TITLE
Fix #705. Checkpoint conflict forces a blockchain write, but does so …

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -834,7 +834,7 @@ class Network(util.DaemonThread):
                         next_height = None
                     else:
                         interface.print_error('checkpoint conflicts with existing fork', branch.path())
-                        branch.write('', 0)
+                        branch.write(b'', 0)
                         branch.save_header(interface.bad_header)
                         interface.mode = 'catch_up'
                         interface.blockchain = branch


### PR DESCRIPTION
…using a str when it should use a bytes.