### PR TITLE
Fixed incorrect modal dialog usage on ExternalPluginsPreviewDialog (breaks on Mac)

### DIFF
--- a/gui/qt/external_plugins_window.py
+++ b/gui/qt/external_plugins_window.py
@@ -53,7 +53,7 @@ INSTALL_ERROR_MESSAGES = {
 
 class ExternalPluginsPreviewDialog(WindowModalDialog):
     def __init__(self, plugin_dialog, main_window, title, plugin_path=None, plugin_metadata=None):
-        WindowModalDialog.__init__(self, main_window, title)
+        WindowModalDialog.__init__(self, plugin_dialog, title)
         
         self.is_preview = plugin_metadata is None
 


### PR DESCRIPTION
 This works ok on Windows and Linux but breaks on Mac.

On mac it led to the Plugin Preview dialog never appearing and the app being stuck in a local event loop forever.

This is because macs are more restrictive and a modal dialog window really is modal to its parent -- and this class made its parent be "main window" previously, which was modaled-out.

Now it correctly made its parent be the already-modal "plugins" window.

Everything is peachy.


