### PR TITLE
Fix #611.  User selects cpfp menu item, then fills out the dialog, bu…

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -3052,4 +3052,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.show_error(_('Max fee exceeded'))
             return
         new_tx = self.wallet.cpfp(parent_tx, fee)
+        if new_tx is None:
+            self.show_error(_('CPFP no longer valid'))
+            return
         self.show_transaction(new_tx)


### PR DESCRIPTION
…t the cpfp is no longer valid at that point.  Rather than crashing, it now shows an error dialog.