### PR TITLE
Freeze Packages

### DIFF
--- a/contrib/deterministic-build/requirements-binaries.txt
+++ b/contrib/deterministic-build/requirements-binaries.txt
@@ -1,5 +1,5 @@
-pycryptodomex==3.4.12
-PyQt5==5.10
-sip==4.19.7
+pycryptodomex==3.6.1
+PyQt5==5.10.1
+sip==4.19.8
 six==1.11.0
-websocket-client==0.46.0
+websocket-client==0.48.0

--- a/contrib/deterministic-build/requirements-hw.txt
+++ b/contrib/deterministic-build/requirements-hw.txt
@@ -1,8 +1,8 @@
-btchip-python==0.1.24
-certifi==2018.1.18
+btchip-python==0.1.27
+certifi==2018.4.16
 chardet==3.0.4
 click==6.7
-Cython==0.27.3
+Cython==0.28.3
 ecdsa==0.13
 hidapi==0.7.99.post21
 idna==2.6
@@ -10,9 +10,9 @@ keepkey==4.0.2
 libusb1==1.6.4
 mnemonic==0.18
 pbkdf2==1.3
-protobuf==3.5.1
-pyblake2==1.1.0
+protobuf==3.5.2.post1
+pyblake2==1.1.2
 requests==2.18.4
 six==1.11.0
-trezor==0.9.0
+trezor==0.10.1
 urllib3==1.22

--- a/contrib/deterministic-build/requirements.txt
+++ b/contrib/deterministic-build/requirements.txt
@@ -1,14 +1,14 @@
-certifi==2018.1.18
+certifi==2018.4.16
 chardet==3.0.4
 dnspython==1.15.0
 ecdsa==0.13
 idna==2.6
 jsonrpclib-pelix==0.3.1
 pbkdf2==1.3
-protobuf==3.5.1
+protobuf==3.5.2.post1
 pyaes==1.6.1
 PySocks==1.6.8
-qrcode==5.3
+qrcode==6.0
 requests==2.18.4
 six==1.11.0
 urllib3==1.22


### PR DESCRIPTION
A bit of an overdue update of package versions for the deterministic builds.

A notable change is an update for pyqt5, as well as a few HW wallet plugin updates.

I don't have my osx/windows vms set up currently, so it would be great if some people on windows or mac could test it out. Possibly @cculianu and @rt121212121?

Would be good to get merged in before the next release.

Fixes #648 