### PR TITLE
Fix #661. The input values were added to the exported tx json in comm…

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2224,7 +2224,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         file_content = file_content.strip()
         tx_file_dict = json.loads(str(file_content))
         tx = self.tx_from_text(file_content)
-        if len(tx_file_dict['input_values']) >= len(tx.inputs()):
+        # Older saved transaction do not include this key.
+        if 'input_values' in tx_file_dict and len(tx_file_dict['input_values']) >= len(tx.inputs()):
             for i in range(len(tx.inputs())):
                 tx._inputs[i]['value'] = tx_file_dict['input_values'][i]
         return tx


### PR DESCRIPTION
…it 922b133, and are looked for when tx are read from files.  Given the values were added for offline signing, and were not present otherwise, this fix handles their non-presence on tx file import.