### PR TITLE
Fix per-user installations of Electron-Cash using `pip3`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,31 +24,40 @@ data_files = []
 
 if platform.system() in ['Linux', 'FreeBSD', 'DragonFly']:
     parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('--user', dest='is_user', action='store_true', default=False)
+    parser.add_argument('--system', dest='is_user', action='store_false', default=False)
     parser.add_argument('--root=', dest='root_path', metavar='dir', default='/')
-    parser.add_argument('--prefix=', dest='prefix_path', metavar='prefix', default=sys.prefix)
+    parser.add_argument('--prefix=', dest='prefix_path', metavar='prefix', nargs='?', const='/', default=sys.prefix)
     opts, _ = parser.parse_known_args(sys.argv[1:])
 
-    # Use per-user */share directory if the global one is not writable
-    usr_share = os.path.join(opts.prefix_path, "share")
-    if os.access(opts.root_path + usr_share, os.W_OK):
-        # Global /usr/share is writable for us – so just use that
-        pass
-    elif not os.path.exists(opts.root_path + usr_share) and os.access(opts.root_path, os.W_OK):
-        # Global /usr/share does not exist, but / is writable – keep using the global directory
-        # (happens during packaging)
-        pass
+    # Use per-user */share directory if the global one is not writable or if a per-user installation
+    # is attempted
+    user_share   = os.environ.get('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
+    system_share = os.path.join(opts.prefix_path, "share")
+    if not opts.is_user:
+        # Not neccarily a per-user installation try system directories
+        if os.access(opts.root_path + system_share, os.W_OK):
+            # Global /usr/share is writable for us – so just use that
+            share_dir = system_share
+        elif not os.path.exists(opts.root_path + system_share) and os.access(opts.root_path, os.W_OK):
+            # Global /usr/share does not exist, but / is writable – keep using the global directory
+            # (happens during packaging)
+            share_dir = system_share
+        else:
+            # Neither /usr/share (nor / if /usr/share doesn't exist) is writable, use the
+            # per-user */share directory
+            share_dir = user_share
     else:
-        # Neither /usr/share (nor / if /usr/share doesn't exist) is writable, use the
-        # per-user */share directory
-        usr_share = os.environ.get('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
+        # Per-user installation
+        share_dir = user_share
     data_files += [
         # Menu icon
-        (os.path.join(usr_share, 'icons/hicolor/128x128/apps/'), ['icons/electron-cash.png']),
-        (os.path.join(usr_share, 'pixmaps/'),                    ['icons/electron-cash.png']),
+        (os.path.join(share_dir, 'icons/hicolor/128x128/apps/'), ['icons/electron-cash.png']),
+        (os.path.join(share_dir, 'pixmaps/'),                    ['icons/electron-cash.png']),
         # Menu entry
-        (os.path.join(usr_share, 'applications/'), ['electron-cash.desktop']),
+        (os.path.join(share_dir, 'applications/'), ['electron-cash.desktop']),
         # App stream (store) metadata
-        (os.path.join(usr_share, 'metainfo/'), ['org.electroncash.ElectronCash.appdata.xml']),
+        (os.path.join(share_dir, 'metainfo/'), ['org.electroncash.ElectronCash.appdata.xml']),
     ]
 
 setup(


### PR DESCRIPTION
See issue #741.
Current per-user installations are broken if the `--prefix` parameter is empty (for instance: `./setup.py install --prefix=`). While this mostly affects recent Ubuntu & Debian systems since they do this for every per-user installation thanks to a special patch, the issue itself should reproducible on every system.

Additional logic has been added to ensure that a system-wide installation is never attempted if `--user` is passed.