### PR TITLE
Change default fee rate from 10 sats/bytes to 1 sats/byte

### DIFF
--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -288,7 +288,7 @@ class SimpleConfig(PrintError):
         return len(self.fee_estimates)==4
 
     def fee_per_kb(self):
-        return self.get('fee_per_kb', self.max_fee_rate()/2)
+        return self.get('fee_per_kb', self.fee_rates[0])
 
     def estimate_fee(self, size):
         return int(self.fee_per_kb() * size / 1000.)


### PR DESCRIPTION
It didn't occur to me until after @kyuupichan pointed this out.  We're getting "bad" press for having 10sats/byte fee rate.

See this article: https://www.yours.org/content/comparison--bitcoin-cash-wallets-for-newcomers-d9c70464b016

As per his recommendation -- we should default the UI to 1 sats/byte. There is no reason to default to 10 -- miners mine 1. :)

