### PR TITLE
Modify translatable strings with "Electron Cash"

### DIFF
--- a/gui/kivy/uix/dialogs/settings.py
+++ b/gui/kivy/uix/dialogs/settings.py
@@ -17,7 +17,7 @@ Builder.load_string('''
 
 <SettingsDialog@Popup>
     id: settings
-    title: _('Electrum Settings')
+    title: _('Electron Cash Settings')
     disable_pin: False
     use_encryption: False
     BoxLayout:

--- a/gui/kivy/uix/ui_screens/network.kv
+++ b/gui/kivy/uix/ui_screens/network.kv
@@ -13,7 +13,7 @@ Popup:
                 SettingsItem:
                     value: _("{} connections.").format(app.num_nodes) if app.num_nodes else _("Not connected")
                     title: _("Status") + ': ' + self.value
-                    description: _("Connections with Electrum servers")
+                    description: _("Connections with Electron Cash servers")
                     action: lambda x: None
 
                 CardSeparator

--- a/gui/kivy/uix/ui_screens/server.kv
+++ b/gui/kivy/uix/ui_screens/server.kv
@@ -6,7 +6,7 @@ Popup:
         padding: '10dp'
         spacing: '10dp'
         TopLabel:
-            text: _("Electrum requests your transaction history from a single server. The returned history is checked against blockchain headers sent by other nodes, using Simple Payment Verification (SPV).")
+            text: _("Electron Cash requests your transaction history from a single server. The returned history is checked against blockchain headers sent by other nodes, using Simple Payment Verification (SPV).")
             font_size: '6pt'
         Widget:
             size_hint: 1, 0.8

--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -165,7 +165,7 @@ class ElectrumGui:
 
     def show_network_dialog(self, parent):
         if not self.daemon.network:
-            parent.show_warning(_('You are using Electrum in offline mode; restart Electrum if you want to get connected'), title=_('Offline'))
+            parent.show_warning(_('You are using Electron Cash in offline mode; restart Electron Cash if you want to get connected'), title=_('Offline'))
             return
         if self.nd:
             self.nd.on_update()

--- a/gui/qt/seed_dialog.py
+++ b/gui/qt/seed_dialog.py
@@ -69,10 +69,10 @@ class SeedLayout(QVBoxLayout):
                 if b:
                     msg = ' '.join([
                         '<b>' + _('Warning') + ':</b>  ',
-                        _('BIP39 seeds can be imported in Electrum, so that users can access funds locked in other wallets.'),
+                        _('BIP39 seeds can be imported in Electron Cash, so that users can access funds locked in other wallets.'),
                         _('However, we do not generate BIP39 seeds, because they do not meet our safety standard.'),
                         _('BIP39 seeds do not include a version number, which compromises compatibility with future software.'),
-                        _('We do not guarantee that BIP39 imports will always be supported in Electrum.'),
+                        _('We do not guarantee that BIP39 imports will always be supported in Electron Cash.'),
                     ])
                 else:
                     msg = ''
@@ -92,11 +92,11 @@ class SeedLayout(QVBoxLayout):
                 if b:
                     msg = ' '.join([
                         '<b>' + _('Warning') + ': BIP39 seeds are dangerous!' + '</b><br/><br/>',
-                        _('BIP39 seeds can be imported in Electrum so that users can access funds locked in other wallets.'),
+                        _('BIP39 seeds can be imported in Electron Cash so that users can access funds locked in other wallets.'),
                         _('However, BIP39 seeds do not include a version number, which compromises compatibility with future wallet software.'),
                         '<br/><br/>',
-                        _('We do not guarantee that BIP39 imports will always be supported in Electrum.'),
-                        _('In addition, Electrum does not verify the checksum of BIP39 seeds; make sure you type your seed correctly.'),
+                        _('We do not guarantee that BIP39 imports will always be supported in Electron Cash.'),
+                        _('In addition, Electron Cash does not verify the checksum of BIP39 seeds; make sure you type your seed correctly.'),
                     ])
                 else:
                     msg = ''

--- a/ios/ElectronCash/electroncash_gui/ios_native/network_dialog.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/network_dialog.py
@@ -491,17 +491,17 @@ def showHelpForButton(oid : objc_id) -> None:
     msg = _("Unknown")
     if tag is TAG_HELP_STATUS:
         msg = ' '.join([
-            _("Electrum connects to several nodes in order to download block headers and find out the longest blockchain."),
+            _("Electron Cash connects to several nodes in order to download block headers and find out the longest blockchain."),
             _("This blockchain is used to verify the transactions sent by your transaction server.")
         ])
     elif tag is TAG_HELP_SERVER:
-        msg = _("Electrum sends your wallet addresses to a single server, in order to receive your transaction history.")
+        msg = _("Electron Cash sends your wallet addresses to a single server, in order to receive your transaction history.")
     elif tag is TAG_HELP_BLOCKCHAIN:
         msg = _('This is the height of your local copy of the blockchain.')
     elif tag is TAG_HELP_AUTOSERVER:
         msg = ' '.join([
-            _("If auto-connect is enabled, Electrum will always use a server that is on the longest blockchain."),
-            _("If it is disabled, you have to choose a server you want to use. Electrum will warn you if your server is lagging.")
+            _("If auto-connect is enabled, Electron Cash will always use a server that is on the longest blockchain."),
+            _("If it is disabled, you have to choose a server you want to use. Electron Cash will warn you if your server is lagging.")
         ])
     msg = msg.replace("Electrum","Electron Cash")
     parent().show_message(msg)

--- a/ios/ElectronCash/electroncash_gui/ios_native/sign_decrypt_dialog.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/sign_decrypt_dialog.py
@@ -237,7 +237,7 @@ class SignDecryptVC(SignDecryptBase):
                         "private key, and verifying with the corresponding public key. The "
                         "address you have entered does not have a unique public key, so these "
                         "operations cannot be performed.") + '\n\n' + \
-                       _('The operation is undefined. Not just in Electrum, but in general.')
+                       _('The operation is undefined. Not just in Electron Cash, but in general.')
             parent().show_message(_('Cannot sign messages with this type of address.') + '\n\n' + msg_sign)
             return
         if not parent().wallet:

--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -744,7 +744,7 @@ class DeviceMgr(ThreadJob, PrintError):
         # The user input has wrong PIN or passphrase, or cancelled input,
         # or it is not pairable
         raise DeviceUnpairableError(
-            _('Electrum cannot pair with your {}.\n\n'
+            _('Electron Cash cannot pair with your {}.\n\n'
               'Before you request bitcoins to be sent to addresses in this '
               'wallet, ensure you can pair with your device, or that you have '
               'its seed (and passphrase, if any).  Otherwise all bitcoins you '

--- a/plugins/labels/__init__.py
+++ b/plugins/labels/__init__.py
@@ -2,7 +2,7 @@ from electroncash.i18n import _
 
 fullname = _('LabelSync')
 description = ' '.join([
-    _("Save your wallet labels on a remote server, and synchronize them across multiple devices where you use Electrum."),
+    _("Save your wallet labels on a remote server, and synchronize them across multiple devices where you use Electron Cash."),
     _("Labels, transactions IDs and addresses are encrypted before they are sent to the remote server.")
 ])
 available_for = ['qt', 'kivy']


### PR DESCRIPTION
"Electron Cash" naming. For upcoming translations (issue #746).