### PR TITLE
Offline signing for Trezor.

### DIFF
--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -580,6 +580,11 @@ class Hardware_KeyStore(KeyStore, Xpub):
     def can_change_password(self):
         return False
 
+    def needs_prevtx(self):
+        '''Returns true if this hardware wallet needs to know the input
+        transactions to sign a transactions'''
+        return True
+
 
 
 def bip39_normalize_passphrase(passphrase):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1187,10 +1187,11 @@ class Abstract_Wallet(PrintError):
                     txin['prev_tx'] = inputtx   # may be needed by hardware wallets
 
     def add_hw_info(self, tx):
-        # add previous tx for hw wallets, if not already there
-        for txin in tx.inputs():
-            if 'prev_tx' not in txin:
-                txin['prev_tx'] = self.get_input_tx(txin['prevout_hash'])
+        # add previous tx for hw wallets, if needed and not already there
+        if any([(isinstance(k, Hardware_KeyStore) and k.can_sign(tx) and k.needs_prevtx()) for k in self.get_keystores()]):
+            for txin in tx.inputs():
+                if 'prev_tx' not in txin:
+                    txin['prev_tx'] = self.get_input_tx(txin['prevout_hash'])
         # add output info for hw wallets
         info = {}
         xpubs = self.get_master_public_keys()

--- a/plugins/keepkey/plugin.py
+++ b/plugins/keepkey/plugin.py
@@ -333,7 +333,7 @@ class KeepKeyCompatiblePlugin(HW_PluginBase):
                 txoutputtype.amount = amount
                 if _type == TYPE_SCRIPT:
                     txoutputtype.script_type = self.types.PAYTOOPRETURN
-                    txoutputtype.op_return_data = address.to_ui_string()[2:]
+                    txoutputtype.op_return_data = address.to_script()[2:]
                 elif _type == TYPE_ADDRESS:
                     if address.kind == address.ADDR_P2PKH:
                         txoutputtype.script_type = self.types.PAYTOADDRESS


### PR DESCRIPTION
Since bitcoincash signs the amount, there is no need to download previous transactions, at least for Trezor. This allows real offline signing.

Unfortunately other hardware wallets (I tested keepkey) don't work without previous transactions, so I added a function to `Hardware_Keystore` to indicate whether the hardware needs them.

Also fixed OP_RETURN txs for KeepKey.