### PR TITLE
Remove max_fee config, replace with customfee

### DIFF
--- a/gui/qt/amountedit.py
+++ b/gui/qt/amountedit.py
@@ -104,3 +104,18 @@ class BTCAmountEdit(AmountEdit):
 class BTCkBEdit(BTCAmountEdit):
     def _base_unit(self):
         return BTCAmountEdit._base_unit(self) + '/kB'
+
+class BTCkBEdit2(BTCAmountEdit):
+    def _base_unit(self):
+        return 'sats' + '/kB'
+    def get_amount(self):
+        try:
+            x = Decimal(str(self.text()))
+        except:
+            return None
+        return int( x) if x > 0 else None
+    def setAmount(self, amount):
+        if amount is None:
+            self.setText(" ") # Space forces repaint in case units changed
+        else:
+            self.setText(format_satoshis_plain(amount, 0))

--- a/gui/qt/fee_slider.py
+++ b/gui/qt/fee_slider.py
@@ -16,7 +16,10 @@ class FeeSlider(QSlider):
         self.callback = callback
         self.dyn = False
         self.lock = threading.RLock()
-        self.update()
+        if (self.config.get('customfee') is None):
+           self.update()
+        else:
+            self.deactivate()
         self.valueChanged.connect(self.moved)
 
     def moved(self, pos):
@@ -45,6 +48,18 @@ class FeeSlider(QSlider):
             fee_rate = self.config.fee_per_kb()
             pos = min(fee_rate / self.fee_step, 10)
             self.setRange(0, 9)
+            self.setValue(pos)
+            tooltip = self.get_tooltip(pos, fee_rate)
+            self.setToolTip(tooltip)
+
+    # configuraing this as is done is here still required, can't just set range 0,0 to deactivate.
+    # chose to make this a seperate function from update for easier code maintainence
+    def deactivate(self):
+        with self.lock:
+            self.fee_step = self.config.max_fee_rate() / 10
+            fee_rate = self.config.fee_per_kb()
+            pos = min(fee_rate / self.fee_step, 10)
+            self.setRange(0, 0)
             self.setValue(pos)
             tooltip = self.get_tooltip(pos, fee_rate)
             self.setToolTip(tooltip)

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -287,8 +287,17 @@ class SimpleConfig(PrintError):
     def has_fee_estimates(self):
         return len(self.fee_estimates)==4
 
-    def fee_per_kb(self):
-        return self.get('fee_per_kb', self.max_fee_rate()/2)
+    def custom_fee_rate(self):
+        f = self.get('customfee')
+        return f
+
+    def fee_per_kb(self): 
+       retval=self.get('customfee')
+       if (retval is None):
+           retval=self.get('fee_per_kb')                
+       if (retval is None):
+           retval=1000  # New wallet
+       return retval
 
     def estimate_fee(self, size):
         return int(self.fee_per_kb() * size / 1000.)


### PR DESCRIPTION
The previous confirmation field "Max fee" had not been in use for some time.  It used to be used to calibrate the fee slider by first setting the max fee, which became the maximum value of the fee slider, and lesser values were extrapolated from it.  

That was then removed so that the slider only allowed one set of fees: from 1-10 sats/byte.  

Now with lower fees in the possible future, we want to allow more flexibility.  But rather than re-introduce the max_fee, which is somewhat convoluted, a simpler setup is proposed:  We just have one field which is a fixed satoshis per Kb, called "customfee" (Custom Fee Rate).  

If customfee is None, then the slider retains the 1-10 sats/byte set.  Otherwise, the singular value of customfee is used in Sats/kB.  Here kilobytes not bytes is preferred to keep things simple with integer values.  Makes usages and storage more straightforward despite being different than the slider.

A warning message is brought back to the tx confirmation if the fee is less than 1000 sats/kB , since currently not all miners accept those low fees.  

Finally, the start up config value for new wallets is 1 sat/byte using the slider.