### PR TITLE
Fee slider modifications and messaging as discussed in Slack on 7/4/18

### DIFF
--- a/gui/qt/amountedit.py
+++ b/gui/qt/amountedit.py
@@ -105,17 +105,19 @@ class BTCkBEdit(BTCAmountEdit):
     def _base_unit(self):
         return BTCAmountEdit._base_unit(self) + '/kB'
 
-class BTCkBEdit2(BTCAmountEdit):
+class BTCSatsByteEdit(BTCAmountEdit):
+    def __init__(self, parent=None):
+        BTCAmountEdit.__init__(self, decimal_point = lambda: 2, is_int = False, parent = parent)
     def _base_unit(self):
-        return 'sats' + '/kB'
+        return 'sats' + '/B'
     def get_amount(self):
         try:
-            x = Decimal(str(self.text()))
+            x = float(Decimal(str(self.text())))
         except:
             return None
-        return int( x) if x > 0 else None
+        return x if x > 0.0 else None    
     def setAmount(self, amount):
         if amount is None:
             self.setText(" ") # Space forces repaint in case units changed
         else:
-            self.setText(format_satoshis_plain(amount, 0))
+            self.setText(str(round(amount*100.0)/100.0))

--- a/gui/qt/fee_slider.py
+++ b/gui/qt/fee_slider.py
@@ -16,10 +16,7 @@ class FeeSlider(QSlider):
         self.callback = callback
         self.dyn = False
         self.lock = threading.RLock()
-        if (self.config.get('customfee') is None):
-           self.update()
-        else:
-            self.deactivate()
+        self.update()
         self.valueChanged.connect(self.moved)
 
     def moved(self, pos):
@@ -33,33 +30,43 @@ class FeeSlider(QSlider):
     def get_tooltip(self, pos, fee_rate):
         from electroncash.util import fee_levels
         rate_str = self.window.format_fee_rate(fee_rate) if fee_rate else _('unknown')
-        if self.dyn:
+        if self.config.has_custom_fee_rate():
+            tooltip = _('Custom rate: ') + rate_str
+        elif self.dyn:
             tooltip = fee_levels[pos] + '\n' + rate_str
         else:
-            tooltip = 'Fixed rate: ' + rate_str
+            tooltip = _('Fixed rate: ') + rate_str
             if self.config.has_fee_estimates():
                 i = self.config.reverse_dynfee(fee_rate)
                 #tooltip += '\n' + (_('Low fee') if i < 0 else 'Within %d blocks'%i)
         return tooltip
 
     def update(self):
+        if self.config.has_custom_fee_rate():
+            self.update_has_custom_fee_rate()
+        else:
+            self.update_no_custom_fee_rate()
+
+    def update_no_custom_fee_rate(self):
         with self.lock:
             self.fee_step = self.config.max_fee_rate() / 10
             fee_rate = self.config.fee_per_kb()
             pos = min(fee_rate / self.fee_step, 10)
             self.setRange(0, 9)
             self.setValue(pos)
+            self.setEnabled(True)
             tooltip = self.get_tooltip(pos, fee_rate)
             self.setToolTip(tooltip)
 
     # configuraing this as is done is here still required, can't just set range 0,0 to deactivate.
     # chose to make this a seperate function from update for easier code maintainence
-    def deactivate(self):
+    def update_has_custom_fee_rate(self):
         with self.lock:
             self.fee_step = self.config.max_fee_rate() / 10
             fee_rate = self.config.fee_per_kb()
-            pos = min(fee_rate / self.fee_step, 10)
-            self.setRange(0, 0)
+            pos = max(0,min(fee_rate / self.fee_step, 1))
+            self.setRange(0, 1)
             self.setValue(pos)
+            self.setEnabled(False)
             tooltip = self.get_tooltip(pos, fee_rate)
             self.setToolTip(tooltip)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -60,7 +60,7 @@ except:
     plot_history = None
 import electroncash.web as web
 
-from .amountedit import AmountEdit, BTCAmountEdit, MyLineEdit, BTCkBEdit, BTCkBEdit2
+from .amountedit import AmountEdit, BTCAmountEdit, MyLineEdit, BTCkBEdit, BTCSatsByteEdit
 from .qrcodewidget import QRCodeWidget, QRDialog
 from .qrtextedit import ShowQRTextEdit, ScanQRTextEdit
 from .transaction_dialog import show_transaction
@@ -2659,15 +2659,16 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         gui_widgets.append((nz_label, nz))
 
         def on_customfee(x):
-            m = customfee_e.get_amount()
+            amt = customfee_e.get_amount()
+            m = amt * 1000.0 if amt is not None else None
             self.config.set_key('customfee', m) 
             self.fee_slider.update()
             self.fee_slider_mogrifier()
     
-        customfee_e = BTCkBEdit2(self.get_decimal_point) 
-        customfee_e.setAmount(self.config.custom_fee_rate())
+        customfee_e = BTCSatsByteEdit() 
+        customfee_e.setAmount(self.config.custom_fee_rate() / 1000.0 if self.config.has_custom_fee_rate() else None)
         customfee_e.textChanged.connect(on_customfee)
-        customfee_label = HelpLabel(_('Custom Fee Rate'), _('Custom Fee Rate in Satoshis per kB')) 
+        customfee_label = HelpLabel(_('Custom Fee Rate'), _('Custom Fee Rate in Satoshis per byte')) 
         fee_widgets.append((customfee_label, customfee_e))
 
         feebox_cb = QCheckBox(_('Edit fees manually'))

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -211,10 +211,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.new_fx_history_signal.connect(self.on_fx_history)
 
         # update fee slider in case we missed the callback
-        if (self.config.get('customfee') is None):
-            self.fee_slider.update()
-        else:
-            self.fee_slider.deactivate() 
+        self.fee_slider.update()
         self.load_wallet(wallet)
         self.connect_slots(gui_object.timer)
         self.fetch_alias()
@@ -2638,12 +2635,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         def on_customfee(x):
             m = customfee_e.get_amount()
-            if (m is None):
-                self.fee_slider.update()
-            else:
-                self.fee_slider.deactivate()
             self.config.set_key('customfee', m) 
-
+            self.fee_slider.update()
     
         customfee_e = BTCkBEdit2(self.get_decimal_point) 
         customfee_e.setAmount(self.config.custom_fee_rate())

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2660,7 +2660,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         def on_customfee(x):
             amt = customfee_e.get_amount()
-            m = amt * 1000.0 if amt is not None else None
+            m = int(amt * 1000.0) if amt is not None else None
             self.config.set_key('customfee', m) 
             self.fee_slider.update()
             self.fee_slider_mogrifier()

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -301,7 +301,9 @@ class SimpleConfig(PrintError):
 
     def has_custom_fee_rate(self):
         i = -1
-        # defensive programming below.. to ensure the custom fee rate is valid ;)
+        # Defensive programming below.. to ensure the custom fee rate is valid ;)
+        # This function mainly controls the appearance (or disappearance) of the fee slider in the send tab in Qt GUI
+        # It is tied to the GUI preferences option 'Custom fee rate'.
         try:
             i = int(self.custom_fee_rate())
         except (ValueError, TypeError):

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -292,12 +292,21 @@ class SimpleConfig(PrintError):
         return f
 
     def fee_per_kb(self): 
-       retval=self.get('customfee')
-       if (retval is None):
-           retval=self.get('fee_per_kb')                
-       if (retval is None):
-           retval=1000  # New wallet
+       retval = self.get('customfee')
+       if retval is None:
+           retval = self.get('fee_per_kb')                
+       if retval is None:
+           retval = 1000  # New wallet
        return retval
+
+    def has_custom_fee_rate(self):
+        i = -1
+        # defensive programming below.. to ensure the custom fee rate is valid ;)
+        try:
+            i = int(self.custom_fee_rate())
+        except (ValueError, TypeError):
+            pass
+        return i >= 0
 
     def estimate_fee(self, size):
         return int(self.fee_per_kb() * size / 1000.)


### PR DESCRIPTION
What's new:

If "Custom Fee Rate" is specified in preferences then:

1. Fee slider disappears
2. It's replaced by a label (well, a HelpLabel actually) that shows the fee rate as calculated from the custom fee rate and/or manual fee override (manual fee override wins, but the custom fee rate is the initial default)

If "Custom Fee Rate" is not specified in preferences (this is the default on new installs), then:

1. Fee slider is visible and works as normal
2. The aforementioned help label is always hidden.

- Note that I also cleaned up Jonald's code from the last commit and refactored it, and also made it play nice with the esoteric "CPFP" dialog which you can get from an unconfirmed tx, if you right-click on it in "history" and do "Child pays for parent"
