### PR TITLE
Fixed locales for MacOS and also removed pbkdf2 dependency for MacOS

### DIFF
--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -51,14 +51,15 @@ rm -rf ./dist
 rm  -rf $BUILDDIR > /dev/null 2>&1
 mkdir $BUILDDIR
 
-info "Downloading icons and locale..."
-for repo in icons locale; do
+info "Downloading icons..."
+for repo in icons; do
   git clone $GIT_REPO-$repo $BUILDDIR/electrum-$repo
 done
 
-cp -R $BUILDDIR/electrum-locale/locale/ ./lib/locale/
 cp    $BUILDDIR/electrum-icons/icons_rc.py ./gui/qt/
 
+info "Making locale..."
+./contrib/make_locale || fail "Failed to make locale..."
 
 info "Downloading libusb..."
 curl https://homebrew.bintray.com/bottles/libusb-1.0.21.el_capitan.bottle.tar.gz | \

--- a/contrib/deterministic-build/requirements-hw.txt
+++ b/contrib/deterministic-build/requirements-hw.txt
@@ -9,7 +9,6 @@ idna==2.6
 keepkey==4.0.2
 libusb1==1.6.4
 mnemonic==0.18
-pbkdf2==1.3
 protobuf==3.5.2.post1
 pyblake2==1.1.2
 requests==2.18.4

--- a/contrib/deterministic-build/requirements.txt
+++ b/contrib/deterministic-build/requirements.txt
@@ -4,7 +4,6 @@ dnspython==1.15.0
 ecdsa==0.13
 idna==2.6
 jsonrpclib-pelix==0.3.1
-pbkdf2==1.3
 protobuf==3.5.2.post1
 pyaes==1.6.1
 PySocks==1.6.8


### PR DESCRIPTION
- Locales for the contrib/build_osx/make_osx script were still pulling the old electrum locales. Fixed this to use the new crowding mechanism (from make_locales script)

- Apparently we no longer depend on pbkdf2, so I removed this as a dependency from macOS

I just wanted to let you guys know about this change which is why I made a PR.

I may just merge this soon anyway if I don't hear back from you guys.
