### PR TITLE
Allow multiple push data and hex in OP_RETURN feature

### DIFF
--- a/lib/address.py
+++ b/lib/address.py
@@ -255,7 +255,11 @@ class ScriptOutput(namedtuple("ScriptAddressTuple", "script")):
                     def lookup(x):
                         return OpCodes.reverseLookup.get(x, ('('+str(x)+')'))
                     if isinstance(op, tuple):
-                        ret += lookup(op[0]) + " " + op[1].decode('utf-8')
+                        try:
+                            ret += lookup(op[0]) + " " + op[1].decode('utf-8')
+                        except UnicodeDecodeError:
+                            import binascii
+                            ret += lookup(op[0]) + " " + op[1].hex()
                     elif isinstance(op, int):
                         ret += lookup(op)
                     else:


### PR DESCRIPTION
Use `<push>` tag to have multiple push data fields.

This can be used in combination `<hex>` to insert binary data in hex format

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/988195/42915918-9379e9c8-8ad0-11e8-8820-4cf2f03ae764.png">

Address.py needed a simple update to handle display of hex data with multiple pushdata fields.
<img width="717" alt="image" src="https://user-images.githubusercontent.com/988195/42915944-abf11472-8ad0-11e8-82f6-74457acfe9ba.png">
