### PR TITLE
Made AddressDialog and TxDialog update in realtime

### DIFF
--- a/gui/qt/address_dialog.py
+++ b/gui/qt/address_dialog.py
@@ -98,6 +98,14 @@ class AddressDialog(WindowModalDialog):
         self.format_amount = self.parent.format_amount
         self.hw.update()
 
+        # connect slots so the embedded history list gets updated whenever the history changes
+        parent.history_updated_signal.connect(self.hw.update)
+        parent.network_signal.connect(self.got_verified_tx)
+
+    def got_verified_tx(self, event, args):
+        if event == 'verified':
+            self.hw.update_item(*args)
+
     def update_addr(self):
         self.addr_e.setText(self.address.to_full_ui_string())
 

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -102,6 +102,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
     computing_privkeys_signal = pyqtSignal()
     show_privkeys_signal = pyqtSignal()
     cashaddr_toggled_signal = pyqtSignal()
+    history_updated_signal = pyqtSignal()
 
     def __init__(self, gui_object, wallet):
         QMainWindow.__init__(self)
@@ -227,6 +228,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.history_list.refresh_headers()
         self.history_list.update()
         self.address_list.update()
+        self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
 
     def on_quotes(self, b):
         self.new_fx_quotes_signal.emit()
@@ -241,6 +243,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         # History tab needs updating if it used spot
         if self.fx.history_used_spot:
             self.history_list.update()
+            self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
 
     def toggle_tab(self, tab):
         show = not self.config.get('show_{}_tab'.format(tab.tab_name), False)
@@ -375,6 +378,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         else:
             self.show()
         self.watching_only_changed()
+        self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
         run_hook('load_wallet', wallet, self)
 
     def init_geometry(self):
@@ -812,6 +816,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.contact_list.update()
         self.invoice_list.update()
         self.update_completions()
+        self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
 
     def create_history_tab(self):
         from .history_list import HistoryList
@@ -1816,6 +1821,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.wallet.delete_address(addr)
             self.address_list.update()
             self.history_list.update()
+            self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
             self.clear_receive_tab()
 
     def get_coins(self, isInvoice = False):
@@ -1859,6 +1865,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.contacts[address] = ('address', label)
         self.contact_list.update()
         self.history_list.update()
+        self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
         self.update_completions()
         return True
 
@@ -1869,6 +1876,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         for label in labels:
             self.contacts.pop(label)
         self.history_list.update()
+        self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
         self.contact_list.update()
         self.update_completions()
 
@@ -1908,6 +1916,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             if self.question(_('Delete invoice?')):
                 self.invoices.remove(key)
                 self.history_list.update()
+                self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
                 self.invoice_list.update()
                 d.close()
         deleteButton = EnterButton(_('Delete'), do_delete)
@@ -2512,6 +2521,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.show_critical(_("Electron Cash was unable to import your labels.") + "\n" + str(reason))
         self.address_list.update()
         self.history_list.update()
+        self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
 
     def do_export_labels(self):
         labels = self.wallet.labels
@@ -2655,6 +2665,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.show_critical(_("The following inputs could not be imported") + ':\n'+ '\n'.join(bad))
         self.address_list.update()
         self.history_list.update()
+        self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
 
     def import_addresses(self):
         if not self.wallet.can_import_address():
@@ -2679,6 +2690,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.fiat_receive_e.setVisible(b)
         self.history_list.refresh_headers()
         self.history_list.update()
+        self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
         self.address_list.refresh_headers()
         self.address_list.update()
         self.update_status()
@@ -2764,6 +2776,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 self.num_zeros = value
                 self.config.set_key('num_zeros', value, True)
                 self.history_list.update()
+                self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
                 self.address_list.update()
         nz.valueChanged.connect(on_nz)
         gui_widgets.append((nz_label, nz))
@@ -2865,6 +2878,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             self.config.set_key('decimal_point', self.decimal_point, True)
             nz.setMaximum(self.decimal_point)
             self.history_list.update()
+            self.history_updated_signal.emit() # inform things like address_dialog that there's a new history
             self.request_list.update()
             self.address_list.update()
             for edit, amount in zip(edits, amounts):

--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -128,6 +128,18 @@ class TxDialog(QDialog, MessageBoxMixin):
         vbox.addLayout(hbox)
         self.update()
 
+        # connect slots so we update in realtime as blocks come in, etc
+        parent.history_updated_signal.connect(self.update_tx_if_in_wallet)
+        parent.network_signal.connect(self.got_verified_tx)
+
+    def got_verified_tx(self, event, args):
+        if event == 'verified' and args[0] == self.tx.txid():
+            self.update()
+
+    def update_tx_if_in_wallet(self):
+        if self.tx.txid() in self.wallet.transactions:
+            self.update()
+
     def do_broadcast(self):
         self.main_window.push_top_level_window(self)
         try:

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -562,7 +562,7 @@ class Abstract_Wallet(PrintError):
         height = conf = timestamp = None
         tx_hash = tx.txid()
         if tx.is_complete():
-            if tx_hash in self.transactions.keys():
+            if tx_hash in self.transactions:
                 label = self.get_label(tx_hash)
                 height, conf, timestamp = self.get_tx_height(tx_hash)
                 if height > 0:


### PR DESCRIPTION
It always irked me that if you kept the address detail window open or the transaction detail window open, they would remain stale and not update as new stuff comes in off the network.

For instance the tx dialog would stay at "Unverified" or "0 confirmations" for all eternity.

And the address detail dialog would never receive updates from the network.

This fixes that.

I added this because Mark Lundberg was also asking for it.
