### PR TITLE
print OP_RETURN pushes in a nicer way

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -296,8 +296,14 @@ class TxDialog(QDialog, MessageBoxMixin):
         o_text.clear()
         cursor = o_text.textCursor()
         for addr, v in self.tx.get_outputs():
-            cursor.insertText(addr.to_ui_string(), text_format(addr))
+            addrstr = addr.to_ui_string()
+            cursor.insertText(addrstr, text_format(addr))
             if v is not None:
-                cursor.insertText('\t', ext)
+                if len(addrstr) > 42: # for long outputs, make a linebreak.
+                    cursor.insertBlock()
+                    addrstr = '\u21b3'
+                    cursor.insertText(addrstr, ext)
+                # insert enough spaces until column 43, to line up amounts
+                cursor.insertText(' '*(43 - len(addrstr)), ext)
                 cursor.insertText(format_amount(v), ext)
             cursor.insertBlock()


### PR DESCRIPTION
This is an idea ported over from the SLP wallet. Electron cash currently prints OP_RETURN pushed binary data in a really hideous way. This PR changes it to print in a much nicer way.

Before:
![screenshot from 2018-09-18 12-18-30](https://user-images.githubusercontent.com/36528214/45713021-bf81f180-bb42-11e8-9e3d-e06bd0a8c342.png)

After:
![screenshot from 2018-09-18 12-40-43](https://user-images.githubusercontent.com/36528214/45713037-cf99d100-bb42-11e8-81b5-3791a6f4fbf9.png)
