### PR TITLE
Fix for issue #860 - "Bad Tx's with dust outputs spoiling the fun"

### DIFF
--- a/lib/coinchooser.py
+++ b/lib/coinchooser.py
@@ -163,7 +163,7 @@ class CoinChooserBase(PrintError):
         self.print_error('change:', change)
         if dust:
             self.print_error('not keeping dust', dust)
-        return change
+        return change, dust
 
     def make_tx(self, coins, outputs, change_addrs, fee_estimator,
                 dust_threshold):
@@ -200,8 +200,9 @@ class CoinChooserBase(PrintError):
         # This takes a count of change outputs and returns a tx fee;
         # each pay-to-bitcoin-address output serializes as 34 bytes
         fee = lambda count: fee_estimator(tx_size + count * 34)
-        change = self.change_outputs(tx, change_addrs, fee, dust_threshold)
+        change, dust = self.change_outputs(tx, change_addrs, fee, dust_threshold)
         tx.add_outputs(change)
+        tx.ephemeral['dust_to_fee'] = dust
 
         self.print_error("using %d inputs" % len(tx.inputs()))
         self.print_error("using buckets:", [bucket.desc for bucket in buckets])

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -413,6 +413,12 @@ class Transaction:
         self._outputs = None
         self.locktime = 0
         self.version = 1
+        
+        # Ephemeral meta-data used internally to keep track of interesting things.
+        # This is currently written-to by coinchooser to tell UI code about 'dust_to_fee', which
+        # is change that's too small to go to change outputs (below dust threshold) and needed
+        # to go to the fee. Values in this dict are advisory only and may or may not always be there!
+        self.ephemeral = dict()
 
     def update(self, raw):
         self.raw = raw

--- a/lib/util.py
+++ b/lib/util.py
@@ -431,7 +431,7 @@ def format_satoshis(x, num_zeros=0, decimal_point=8, precision=None, is_diff=Fal
     return result
 
 def format_fee_satoshis(fee, num_zeros=0):
-    return format_satoshis(fee, num_zeros, 0, precision=1)
+    return format_satoshis(fee, num_zeros, 0, precision=num_zeros)
 
 def timestamp_to_datetime(timestamp):
     try:

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -79,8 +79,9 @@ def relayfee(network):
 
 def dust_threshold(network):
     # Change < dust threshold is added to the tx fee
-    #return 182 * 3 * relayfee(network) / 1000
-    return 1
+    #return 182 * 3 * relayfee(network) / 1000 # original Electrum logic
+    #return 1 # <-- was this value until late Sept. 2018
+    return 546 # hard-coded Bitcoin Cash dust threshold. Was changed to this as of Sept. 2018
 
 
 def append_utxos_to_inputs(inputs, network, pubkey, txin_type, imax):


### PR DESCRIPTION
This was an issue previously that went undetected/unaddresses for a while.

See #860.

This fix:

1. Sets internal 'dust_threshold' to network-wide hard-coded value of 546
2. This has the (desired) side effect of dust outputs no longer being appended to a tx (which caused tx to get rejected). Instead they are added to fee (which is just about the only thing that you can do).
3. User is told about this addition to the fee.

In addition, this PR fixes a formatting issue of the 'fee rate' in the transaction dialog screen (fee was rounded to nearest sat/B, rather than displaying fractional eg 1.25 sats/B fees).

Here is a preview:

<img width="757" alt="screen shot 2018-09-21 at 7 31 13 pm" src="https://user-images.githubusercontent.com/266627/45893848-4a7a1a80-bdd5-11e8-9dbb-ce2aee27f868.png">
