### PR TITLE
Made inputs and outputs text edit more prominent/take up more space

### DIFF
--- a/gui/qt/transaction_dialog.py
+++ b/gui/qt/transaction_dialog.py
@@ -93,8 +93,6 @@ class TxDialog(QDialog, MessageBoxMixin):
 
         self.add_io(vbox)
 
-        vbox.addStretch(1)
-
         self.sign_button = b = QPushButton(_("Sign"))
         b.clicked.connect(self.sign)
 
@@ -249,14 +247,12 @@ class TxDialog(QDialog, MessageBoxMixin):
         i_text = QTextEdit()
         i_text.setFont(QFont(MONOSPACE_FONT))
         i_text.setReadOnly(True)
-        i_text.setMaximumHeight(100)
 
         vbox.addWidget(i_text)
         vbox.addWidget(QLabel(_("Outputs") + ' (%d)'%len(self.tx.outputs())))
         o_text = QTextEdit()
         o_text.setFont(QFont(MONOSPACE_FONT))
         o_text.setReadOnly(True)
-        o_text.setMaximumHeight(100)
         vbox.addWidget(o_text)
         self.main_window.cashaddr_toggled_signal.connect(
             partial(self.update_io, i_text, o_text))


### PR DESCRIPTION
As per discussions with Mark Lundeberg, and in preparation for more OP_RETURN action on the blockchain, we think it might be worthwhile to make the tx in/out text area expandable in the tx dialog.

This PR Does that.

See below.  Note how now the Input/Output panes expand to take up vertical space as the window grows.  Note that if the window is shrunk, they do give way and do not eat up any space.  The only difference is that the huge dead area between the buttons and the text fields can no longer happen.  See the below screenshots:

**Before:**

<img width="758" alt="screen shot 2018-09-22 at 12 59 05 am" src="https://user-images.githubusercontent.com/266627/45907985-f25a0d00-be02-11e8-88d1-466d22b80b31.png">

**After:**
<img width="753" alt="screen shot 2018-09-22 at 12 58 36 am" src="https://user-images.githubusercontent.com/266627/45907990-fc7c0b80-be02-11e8-918a-fa16ecb82ccd.png">

